### PR TITLE
Integrate WhatsApp messaging with Google Sheets logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ package-lock.json
 # Backup ou arquivos temporários
 *.bak
 *.tmp
+
+# Sessão do WhatsApp
+server-whatsapp/.wwebjs_auth/

--- a/components/ClientCard.jsx
+++ b/components/ClientCard.jsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import MessageModal from './MessageModal';
 import ObservationModal from './ObservationModal';
 import HistoryModal from './HistoryModal';
+import ModalWhatsApp from './ModalWhatsApp';
 
 function displayPhone(phone) {
   return String(phone || '').replace(/^'+/, ''); // remove proteção visualmente
@@ -76,6 +77,8 @@ export default function ClientCard({ client, onStatusChange }) {
   const [obsAction, setObsAction] = useState(null);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [historyData, setHistoryData] = useState([]);
+  const [waOpen, setWaOpen] = useState(false);
+  const [waNumber, setWaNumber] = useState(null);
 
   const handleDoubleClick = async () => {
     const newColor = 'green';
@@ -122,6 +125,13 @@ export default function ClientCard({ client, onStatusChange }) {
     const history = await res.json();
     setHistoryData(history);
     setHistoryOpen(true);
+  };
+
+  const openWhatsAppModal = () => {
+    const num = client.contacts[0]?.normalizedPhones?.[0];
+    if (!num) return;
+    setWaNumber(num);
+    setWaOpen(true);
   };
 
   const handlePhoneClick = async (e, phone, contact) => {
@@ -295,13 +305,24 @@ export default function ClientCard({ client, onStatusChange }) {
         ))}
       </div>
       <div className="mt-2">
-        <button
-          type="button"
-          className="text-blue-600 underline text-xs"
-          onClick={handleHistoryClick}
-        >
-          Histórico
-        </button>
+        <div className="flex space-x-2">
+          <button
+            type="button"
+            className="text-blue-600 underline text-xs"
+            onClick={handleHistoryClick}
+          >
+            Histórico
+          </button>
+          {client.contacts[0]?.normalizedPhones?.[0] && (
+            <button
+              type="button"
+              className="text-green-600 underline text-xs"
+              onClick={openWhatsAppModal}
+            >
+              💬 WhatsApp
+            </button>
+          )}
+        </div>
       </div>
       <MessageModal
         open={modalOpen}
@@ -324,6 +345,12 @@ export default function ClientCard({ client, onStatusChange }) {
         open={historyOpen}
         interactions={historyData}
         onClose={() => setHistoryOpen(false)}
+      />
+      <ModalWhatsApp
+        open={waOpen}
+        onClose={() => setWaOpen(false)}
+        clienteId={client.id}
+        numero={waNumber}
       />
     </div>
   );

--- a/components/ModalWhatsApp.jsx
+++ b/components/ModalWhatsApp.jsx
@@ -1,0 +1,96 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function ModalWhatsApp({ open, onClose, clienteId, numero }) {
+  const [mensagens, setMensagens] = useState([]);
+  const [texto, setTexto] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      fetch(`/api/whatsapp/historico?clienteId=${clienteId}`)
+        .then((res) => res.json())
+        .then((data) => setMensagens(Array.isArray(data) ? data : []))
+        .catch(() => setMensagens([]));
+    }
+  }, [open, clienteId]);
+
+  const handleSend = async () => {
+    if (!texto.trim()) return;
+    try {
+      await fetch('http://localhost:3000/send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          Cliente_ID: clienteId,
+          Numero: numero,
+          Mensagem: texto,
+        }),
+      });
+      const nova = {
+        Cliente_ID: clienteId,
+        Numero: numero,
+        Mensagem: texto,
+        Direcao: 'enviada',
+        Data_Hora: new Date().toISOString(),
+      };
+      setMensagens((prev) => [...prev, nova]);
+      setTexto('');
+    } catch (err) {
+      console.error('Erro ao enviar mensagem:', err);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+      <div className="bg-white w-full max-w-md p-4 rounded shadow-lg flex flex-col">
+        <div className="flex-1 overflow-y-auto mb-4 space-y-2">
+          {mensagens.map((m, idx) => (
+            <div
+              key={idx}
+              className={`flex ${m.Direcao === 'enviada' ? 'justify-end' : 'justify-start'}`}
+            >
+              <div
+                className={`px-3 py-2 rounded-md max-w-xs text-sm ${{
+                  enviada: 'bg-green-200',
+                  recebida: 'bg-gray-200',
+                }[m.Direcao] || 'bg-gray-200'}`}
+              >
+                <p>{m.Mensagem}</p>
+                {m.Data_Hora && (
+                  <p className="text-[10px] text-gray-500">
+                    {new Date(m.Data_Hora).toLocaleString()}
+                  </p>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className="flex space-x-2">
+          <input
+            type="text"
+            value={texto}
+            onChange={(e) => setTexto(e.target.value)}
+            className="flex-1 border rounded px-2 py-1 text-sm"
+            placeholder="Digite uma mensagem"
+          />
+          <button
+            type="button"
+            onClick={handleSend}
+            className="bg-green-500 text-white px-3 py-1 rounded"
+          >
+            Enviar
+          </button>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="mt-2 text-sm text-gray-600 self-end"
+        >
+          Fechar
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/lib/googleSheets.js
+++ b/lib/googleSheets.js
@@ -40,6 +40,7 @@ async function withCache(key, fn) {
 const SCOPES = ['https://www.googleapis.com/auth/spreadsheets'];
 const SHEET_NAME = 'Sheet1';
 const HISTORY_SHEET_NAME = 'Historico_Interacoes';
+const WHATSAPP_SHEET_NAME = 'HistoricoWhatsApp';
 
 // ✅ Mapeamento de colunas para updateRow
 const COLUMN_MAP = {
@@ -73,6 +74,15 @@ const HISTORY_COLUMN_MAP = {
   canal: 'Canal',
   observacao: 'Observacao',
   mensagem_usada: 'Mensagem_Usada',
+};
+
+// ✅ Mapeamento de colunas da aba de histórico do WhatsApp
+const WHATSAPP_COLUMN_MAP = {
+  cliente_id: 'Cliente_ID',
+  numero: 'Numero',
+  mensagem: 'Mensagem',
+  direcao: 'Direcao',
+  data_hora: 'Data_Hora',
 };
 
 function getAuth() {
@@ -239,6 +249,55 @@ export async function appendHistoryRow(data) {
     valueInputOption: 'USER_ENTERED',
     requestBody: { values: [row] },
   });
+}
+
+// ✅ Insere linha na aba de histórico do WhatsApp
+export async function appendWhatsAppRow(data) {
+  const auth = await authorize();
+  const sheets = google.sheets({ version: 'v4', auth });
+  const row = [
+    protectValue(data.cliente_id || ''),
+    protectValue(data.numero || ''),
+    data.mensagem || '',
+    data.direcao || '',
+    data.data_hora || '',
+  ];
+  return sheets.spreadsheets.values.append({
+    spreadsheetId: process.env.SPREADSHEET_ID,
+    range: WHATSAPP_SHEET_NAME,
+    valueInputOption: 'USER_ENTERED',
+    requestBody: { values: [row] },
+  });
+}
+
+// ✅ Busca histórico do WhatsApp filtrado por Cliente_ID
+export async function getWhatsAppMessagesByClienteId(clienteId) {
+  const auth = await authorize();
+  const sheets = google.sheets({ version: 'v4', auth });
+  const res = await sheets.spreadsheets.values.get({
+    spreadsheetId: process.env.SPREADSHEET_ID,
+    range: WHATSAPP_SHEET_NAME,
+  });
+  const rows = res.data.values || [];
+  if (rows.length === 0) return [];
+  const [header, ...data] = rows;
+  const idx = {
+    cliente: header.indexOf('Cliente_ID'),
+    numero: header.indexOf('Numero'),
+    mensagem: header.indexOf('Mensagem'),
+    direcao: header.indexOf('Direcao'),
+    dataHora: header.indexOf('Data_Hora'),
+  };
+  return data
+    .filter((r) => !clienteId || r[idx.cliente] === clienteId)
+    .map((r) => ({
+      Cliente_ID: r[idx.cliente] || null,
+      Numero: r[idx.numero] || '',
+      Mensagem: r[idx.mensagem] || '',
+      Direcao: r[idx.direcao] || '',
+      Data_Hora: r[idx.dataHora] || '',
+    }))
+    .sort((a, b) => new Date(a.Data_Hora) - new Date(b.Data_Hora));
 }
 
 export async function updateRow(rowNumber, data) {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.5.0",
+    "whatsapp-web.js": "^1.24.0",
+    "qrcode-terminal": "^0.12.0",
+    "express": "^4.18.2",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {

--- a/pages/api/whatsapp/historico.js
+++ b/pages/api/whatsapp/historico.js
@@ -1,0 +1,14 @@
+import { getWhatsAppMessagesByClienteId } from '../../../lib/googleSheets';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return res.status(405).end();
+
+  const clienteId = req.query.clienteId || '';
+  try {
+    const messages = await getWhatsAppMessagesByClienteId(clienteId);
+    return res.status(200).json(messages);
+  } catch (err) {
+    console.error('Erro ao buscar histórico do WhatsApp:', err);
+    return res.status(500).json({ error: 'Falha ao buscar histórico' });
+  }
+}

--- a/pages/api/whatsapp/registrar.js
+++ b/pages/api/whatsapp/registrar.js
@@ -1,0 +1,24 @@
+import { appendWhatsAppRow } from '../../../lib/googleSheets';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return res.status(405).end();
+
+  const { Cliente_ID = null, Numero, Mensagem, Direcao, Data_Hora } = req.body || {};
+  if (!Numero || !Mensagem || !Direcao || !Data_Hora) {
+    return res.status(400).json({ error: 'Dados obrigatórios ausentes' });
+  }
+
+  try {
+    await appendWhatsAppRow({
+      cliente_id: Cliente_ID,
+      numero: Numero,
+      mensagem: Mensagem,
+      direcao: Direcao,
+      data_hora: Data_Hora,
+    });
+    return res.status(200).json({ ok: true });
+  } catch (err) {
+    console.error('Erro ao registrar mensagem do WhatsApp:', err);
+    return res.status(500).json({ error: 'Falha ao registrar mensagem' });
+  }
+}

--- a/server-whatsapp/index.js
+++ b/server-whatsapp/index.js
@@ -1,0 +1,76 @@
+const express = require('express');
+const { Client, LocalAuth } = require('whatsapp-web.js');
+const qrcode = require('qrcode-terminal');
+
+const app = express();
+app.use(express.json());
+
+const whatsapp = new Client({
+  authStrategy: new LocalAuth(),
+  puppeteer: {
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  },
+});
+
+whatsapp.on('qr', (qr) => {
+  console.log('QR RECEIVED');
+  qrcode.generate(qr, { small: true });
+});
+
+whatsapp.on('ready', () => {
+  console.log('WhatsApp client ready');
+});
+
+whatsapp.on('message', async (message) => {
+  const number = message.from.replace(/@c\.us$/, '');
+  const payload = {
+    Cliente_ID: null,
+    Numero: number,
+    Mensagem: message.body,
+    Direcao: 'recebida',
+    Data_Hora: new Date().toISOString(),
+  };
+  try {
+    await fetch('http://localhost:3000/api/whatsapp/registrar', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  } catch (err) {
+    console.error('Erro ao registrar mensagem recebida:', err);
+  }
+});
+
+whatsapp.initialize();
+
+app.post('/send', async (req, res) => {
+  const { Cliente_ID, Numero, Mensagem } = req.body || {};
+  if (!Numero || !Mensagem) {
+    return res.status(400).json({ error: 'Numero e Mensagem são obrigatórios' });
+  }
+  try {
+    const chatId = Numero.includes('@c.us') ? Numero : `${Numero}@c.us`;
+    await whatsapp.sendMessage(chatId, Mensagem);
+    await fetch('http://localhost:3000/api/whatsapp/registrar', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        Cliente_ID: Cliente_ID || null,
+        Numero,
+        Mensagem,
+        Direcao: 'enviada',
+        Data_Hora: new Date().toISOString(),
+      }),
+    });
+    return res.json({ ok: true });
+  } catch (err) {
+    console.error('Erro ao enviar mensagem:', err);
+    return res.status(500).json({ error: 'Falha ao enviar mensagem' });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`WhatsApp service listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- integrate whatsapp-web.js server to send/receive messages and forward logs to Next.js API
- add Google Sheets helpers and API routes to store WhatsApp messages
- add React modal and client button for WhatsApp chat history

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6892669bf004832c9efb0cc418ae282a