### PR TITLE
Improve company enrichment with Perplexity and import flow

### DIFF
--- a/lib/perplexity.js
+++ b/lib/perplexity.js
@@ -1,69 +1,224 @@
-import { appendCompanyImportRow, getCompanySheetCached } from './googleSheets';
-import { enrichCompanyData } from './perplexity';
+// lib/perplexity.js
+// Enriquecimento focado na MATRIZ NO BRASIL, com UMA ÚNICA consulta à Perplexity.
+// Regras de performance:
+// - Só consulta a AI se o CNPJ NÃO estiver presente/normalizável.
+// - Timeout controlável por env: PERPLEXITY_TIMEOUT_MS (default 10000).
+// - Observação deve trazer snapshot econômico conciso e fonte/URL quando possível.
+//
+// Campos suportados:
+// nome, site, pais, estado, cidade, logradouro, numero, bairro, complemento,
+// cep, cnpj, ddi, telefone, telefone2, observacao
 
-export default async function handler(req, res) {
-  if (req.method !== 'POST') {
-    return res.status(405).end();
+const PPLX_ENDPOINT =
+  process.env.PERPLEXITY_ENDPOINT || 'https://api.perplexity.ai/chat/completions';
+const PPLX_MODEL = process.env.PERPLEXITY_MODEL || 'sonar';
+const TIMEOUT_MS = parseInt(process.env.PERPLEXITY_TIMEOUT_MS || '10000', 10);
+
+const UF_LIST = new Set([
+  'AC','AL','AP','AM','BA','CE','DF','ES','GO','MA','MT','MS','MG',
+  'PA','PB','PR','PE','PI','RJ','RN','RS','RO','RR','SC','SP','SE','TO'
+]);
+
+// ==================== Utils ====================
+function norm(v) {
+  if (v == null) return '';
+  return String(v).trim();
+}
+function onlyDigits(s) {
+  return norm(s).replace(/\D+/g, '');
+}
+function onlyAllowedKeys(obj) {
+  const allowed = new Set([
+    'nome','site','pais','estado','cidade','logradouro','numero','bairro',
+    'complemento','cep','cnpj','ddi','telefone','telefone2','observacao'
+  ]);
+  const out = {};
+  for (const k of Object.keys(obj || {})) {
+    if (allowed.has(k)) out[k] = norm(obj[k]);
   }
-
-  const { client } = req.body || {};
-  if (!client) {
-    return res.status(400).json({ error: 'Client data missing' });
+  return out;
+}
+function mergeIfEmpty(base, extra) {
+  const out = { ...base };
+  for (const [k, v] of Object.entries(extra || {})) {
+    if (!out[k] || norm(out[k]) === '') out[k] = v;
   }
+  return out;
+}
 
-  let empresa = {
-    nome: client?.company || '',
-    site: client?.website || '',
-    pais: client?.country || '',
-    estado: client?.state || '',
-    cidade: client?.city || '',
-    logradouro: client?.address || '',
-    numero: client?.number || '',
-    bairro: client?.neighborhood || '',
-    complemento: client?.complement || '',
-    cep: client?.zipcode || '',
-    cnpj: client?.cnpj || '',
-    ddi: client?.ddi || '55',
-    telefone: client?.phone || '',
-    telefone2: client?.phone2 || '',
-    observacao: client?.observation || '',
+// ==================== Normalizadores BR ====================
+function normalizeCNPJ(s) {
+  const digits = onlyDigits(s);
+  if (digits.length !== 14) return '';
+  return digits.replace(/^(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})$/, '$1.$2.$3/$4-$5');
+}
+function normalizeCEP(s) {
+  const digits = onlyDigits(s);
+  if (digits.length !== 8) return '';
+  return digits.replace(/^(\d{5})(\d{3})$/, '$1-$2');
+}
+function normalizeUF(s) {
+  const up = norm(s).toUpperCase();
+  return UF_LIST.has(up) ? up : '';
+}
+function normalizePhoneBR(s) {
+  let t = norm(s);
+  if (!t) return '';
+  t = t.replace(/[^\d+]/g, '');
+  if (t.startsWith('55')) t = '+' + t;
+  if (!t.startsWith('+55')) t = '+55' + t.replace(/^\+?/, '');
+  return t;
+}
+function preferBRDomain(site) {
+  const s = norm(site);
+  if (!s) return '';
+  const parts = s.split(/\s+|\s*\|\s*/).filter(Boolean);
+  if (parts.length <= 1) return s;
+  const brFirst =
+    parts.find(u => /\.com\.br($|\/)/i.test(u)) ||
+    parts.find(u => /\.br($|\/)/i.test(u));
+  return brFirst || parts[0];
+}
+function sanitizeBrazilFields(obj) {
+  const out = { ...obj };
+  out.pais = 'Brasil';
+  // DDI: só setar "55" se existir telefone/telefone2; caso contrário, manter vazio
+  const hasPhone = !!norm(out.telefone) || !!norm(out.telefone2);
+  out.ddi = hasPhone ? '55' : norm(out.ddi) || '';
+  if (out.estado) out.estado = normalizeUF(out.estado);
+  if (out.cep) out.cep = normalizeCEP(out.cep);
+  if (out.cnpj) out.cnpj = normalizeCNPJ(out.cnpj);
+  if (out.site) out.site = preferBRDomain(out.site);
+  if (out.telefone) out.telefone = normalizePhoneBR(out.telefone);
+  if (out.telefone2) out.telefone2 = normalizePhoneBR(out.telefone2);
+  return out;
+}
+
+// ==================== Prompt ====================
+function buildCNPJPrompt(empresa) {
+  const nome = norm(empresa?.nome);
+  const cidade = norm(empresa?.cidade);
+  const estado = norm(empresa?.estado);
+  const pistas = [];
+  if (cidade) pistas.push(`cidade: "${cidade}"`);
+  if (estado) pistas.push(`UF: "${estado}"`);
+  const hint = pistas.length ? `\nPistas: ${pistas.join(' | ')}` : '';
+  return `
+Retorne APENAS um JSON válido sobre a empresa no BRASIL.
+Dê preferência ao CNPJ da MATRIZ (código 0001). Se não houver 0001, retorne outro CNPJ válido da empresa no Brasil.
+Se não tiver certeza do CNPJ, responda cnpj como "" (string vazia). NÃO invente.
+
+Empresa: "${nome}"${hint}
+
+Formato de resposta (JSON estrito):
+{
+  "cnpj": "00.000.000/0000-00",
+  "nome": "",
+  "site": "",
+  "estado": "",
+  "cidade": "",
+  "logradouro": "",
+  "numero": "",
+  "bairro": "",
+  "complemento": "",
+  "cep": "",
+  "telefone": "",
+  "telefone2": "",
+  "observacao": ""
+}
+
+Regras:
+- Sempre Brasil (pais="Brasil").
+- Não invente: se campo incerto, use "".
+- Responda APENAS com o JSON.
+- Mantenha "observacao" objetiva (até ~240 caracteres) e inclua uma fonte/URL quando possível.
+`.trim();
+}
+
+// ==================== HTTP call ====================
+async function callPerplexityJSON(prompt, signal) {
+  const apiKey = process.env.PERPLEXITY_API_KEY;
+  if (!apiKey) throw new Error('PERPLEXITY_API_KEY ausente no .env.local');
+
+  const body = {
+    model: PPLX_MODEL,
+    temperature: 0,
+    messages: [
+      { role: 'system', content: 'Você responde apenas com JSON válido, sem texto fora do JSON.' },
+      { role: 'user', content: prompt }
+    ]
   };
 
-  // verificar duplicidade na planilha
-  try {
-    const sheet = await getCompanySheetCached();
-    const rows = sheet.data.values || [];
-    const [header, ...dataRows] = rows;
-    const idx = {
-      cnpj: header.indexOf('cnpj'),
-      nome: header.indexOf('nome'),
-    };
-    const duplicate = dataRows.some((row) => {
-      const cnpjVal = idx.cnpj >= 0 ? row[idx.cnpj] : '';
-      const nomeVal = idx.nome >= 0 ? row[idx.nome] : '';
-      return (
-        (empresa.cnpj && cnpjVal === empresa.cnpj) ||
-        (empresa.nome && nomeVal && nomeVal.toLowerCase() === empresa.nome.toLowerCase())
-      );
-    });
-    if (duplicate) {
-      return res.status(200).json({ duplicate: true });
-    }
-  } catch (err) {
-    console.error('Erro ao verificar duplicidade:', err);
+  const res = await fetch(PPLX_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(body),
+    signal
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Perplexity API error: ${res.status} ${res.statusText} - ${text}`);
   }
 
-  // enriquecer dados
-  empresa = await enrichCompanyData(empresa);
+  const data = await res.json();
+  const content = data?.choices?.[0]?.message?.content || '';
 
+  // Extrai o primeiro objeto JSON (caso venha com algum ruído)
+  const i = content.indexOf('{');
+  const j = content.lastIndexOf('}');
+  const jsonStr = i >= 0 && j >= 0 ? content.slice(i, j + 1) : content;
+
+  return JSON.parse(jsonStr);
+}
+
+async function withTimeout(fn, ms = TIMEOUT_MS) {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), ms);
   try {
-    const appendRes = await appendCompanyImportRow(empresa);
-    const range = appendRes.data?.updates?.updatedRange || '';
-    const match = range.match(/!(?:[A-Z]+)(\d+):/);
-    const row = match ? parseInt(match[1], 10) : undefined;
-    return res.status(200).json({ row });
-  } catch (err) {
-    console.error('Erro ao registrar planilha:', err);
-    return res.status(500).json({ error: 'Erro ao registrar planilha' });
+    return await fn(controller.signal);
+  } finally {
+    clearTimeout(id);
   }
+}
+
+// ==================== API principal ====================
+export async function enrichCompanyData(empresa) {
+  // Se já houver CNPJ normalizável, NÃO chama a AI.
+  const base = { ...empresa, pais: 'Brasil' };
+  const fixedAlready = normalizeCNPJ(base.cnpj || '');
+  if (fixedAlready) {
+    const sanitized = sanitizeBrazilFields({ ...base, cnpj: fixedAlready });
+    return sanitized;
+  }
+
+  const nome = norm(base.nome);
+  if (!nome) return sanitizeBrazilFields(base);
+
+  const prompt = buildCNPJPrompt(base);
+
+  let enriched = {};
+  try {
+    const raw = await withTimeout((signal) => callPerplexityJSON(prompt, signal), TIMEOUT_MS);
+    enriched = onlyAllowedKeys(raw);
+  } catch (err) {
+    console.error('Perplexity (consulta única) falhou:', err?.message || err);
+    enriched = {};
+  }
+
+  const fixedCNPJ = normalizeCNPJ(enriched.cnpj || '');
+  if (!fixedCNPJ) {
+    const e = new Error('Nenhum CNPJ encontrado para a empresa no Brasil.');
+    e.code = 'CNPJ_NOT_FOUND';
+    // Não derrubamos o fluxo: volta sem CNPJ, mas sanitizado
+    return sanitizeBrazilFields(base);
+  }
+  enriched.cnpj = fixedCNPJ;
+
+  let merged = mergeIfEmpty(base, enriched);
+  merged = sanitizeBrazilFields(merged);
+  return merged;
 }

--- a/pages/api/companies.js
+++ b/pages/api/companies.js
@@ -1,15 +1,82 @@
-import { appendCompanyImportRow, getCompanySheetCached } from '../../lib/googleSheets';
+// pages/api/companies.js
+// Fluxo robusto e rápido:
+// - Verifica duplicidade por CNPJ/Nome na aba de importação.
+// - Se site estiver vazio, tenta derivar domínio a partir dos e-mails existentes na planilha principal,
+//   ignorando domínios genéricos (gmail/outlook/yahoo etc.).
+// - Se não houver telefone, deixa DDI vazio.
+// - Só chama a Perplexity se NÃO houver CNPJ.
+
+import {
+  appendCompanyImportRow,
+  getCompanySheetCached,
+  getSheetCached,
+} from '../../lib/googleSheets';
 import { enrichCompanyData } from '../../lib/perplexity';
 
+const GENERIC_DOMAINS = new Set([
+  'gmail.com','outlook.com','hotmail.com','yahoo.com','icloud.com',
+  'bol.com.br','uol.com.br','terra.com.br','live.com'
+]);
+
+function norm(v) {
+  if (v == null) return '';
+  return String(v).trim();
+}
+function ensureHttps(domain) {
+  if (!domain) return '';
+  return /^https?:\/\//i.test(domain) ? domain : `https://${domain}`;
+}
+function extractDomain(email) {
+  const m = String(email || '').toLowerCase().match(/^[^@]+@([^@]+)$/);
+  return m ? m[1] : '';
+}
+
+// Tenta obter domínio corporativo pela planilha principal (Sheet1),
+// buscando por colunas de e-mail conhecidas e por nome da organização.
+function tryDeriveSiteFromMainSheet(companyName) {
+  return getSheetCached()
+    .then((sheet) => {
+      const rows = sheet.data?.values || [];
+      if (!rows.length) return '';
+      const [header, ...data] = rows;
+
+      const idxOrgA = header.indexOf('Organização - Nome');
+      const idxOrgB = header.indexOf('Negócio - Organização');
+      const idxEmailW = header.indexOf('Pessoa - Email - Work');
+      const idxEmailH = header.indexOf('Pessoa - Email - Home');
+      const idxEmailO = header.indexOf('Pessoa - Email - Other');
+
+      const matches = data.filter((r = []) => {
+        const org =
+          (idxOrgA >= 0 ? r[idxOrgA] : '') ||
+          (idxOrgB >= 0 ? r[idxOrgB] : '');
+        return !!org && norm(org).toLowerCase() === norm(companyName).toLowerCase();
+      });
+
+      for (const r of matches) {
+        const emails = [
+          idxEmailW >= 0 ? r[idxEmailW] : '',
+          idxEmailH >= 0 ? r[idxEmailH] : '',
+          idxEmailO >= 0 ? r[idxEmailO] : '',
+        ].filter(Boolean);
+
+        for (const e of emails) {
+          const domain = extractDomain(e);
+          if (domain && !GENERIC_DOMAINS.has(domain)) {
+            return ensureHttps(domain);
+          }
+        }
+      }
+      return '';
+    })
+    .catch(() => '');
+}
+
 export default async function handler(req, res) {
-  if (req.method !== 'POST') {
-    return res.status(405).end();
-  }
+  if (req.method !== 'POST') return res.status(405).end();
 
   const { client } = req.body || {};
-  if (!client) {
-    return res.status(400).json({ error: 'Client data missing' });
-  }
+  if (!client) return res.status(400).json({ error: 'Client data missing' });
 
   let empresa = {
     nome: client?.company || '',
@@ -23,42 +90,71 @@ export default async function handler(req, res) {
     complemento: client?.complement || '',
     cep: client?.zipcode || '',
     cnpj: client?.cnpj || '',
-    ddi: client?.ddi || '55',
+    ddi: client?.ddi || '',     // regra: só preencher se tiver telefone
     telefone: client?.phone || '',
     telefone2: client?.phone2 || '',
     observacao: client?.observation || '',
   };
 
-  // verificar duplicidade na planilha
+  // 1) Duplicidade na aba de importação (CNPJ ou Nome)
   try {
     const sheet = await getCompanySheetCached();
-    const rows = sheet.data.values || [];
-    const [header, ...dataRows] = rows;
+    const rows = sheet.data?.values || [];
+    const [header = [], ...dataRows] = rows;
+
     const idx = {
-      cnpj: header.indexOf('cnpj'),
-      nome: header.indexOf('nome'),
+      cnpj: header.indexOf('CNPJ Empresa'),
+      nome: header.indexOf('Nome da Empresa'),
     };
-    const duplicate = dataRows.some((row) => {
-      const cnpjVal = idx.cnpj >= 0 ? row[idx.cnpj] : '';
-      const nomeVal = idx.nome >= 0 ? row[idx.nome] : '';
-      return (
-        (empresa.cnpj && cnpjVal === empresa.cnpj) ||
-        (empresa.nome && nomeVal && nomeVal.toLowerCase() === empresa.nome.toLowerCase())
-      );
+
+    const normalize = (v) => (typeof v === 'string' ? v.trim() : v);
+
+    const duplicate = dataRows.some((row = []) => {
+      const cnpjVal = idx.cnpj >= 0 ? normalize(row[idx.cnpj]) : '';
+      const nomeVal = idx.nome >= 0 ? normalize(row[idx.nome]) : '';
+      const sameCnpj = empresa.cnpj && cnpjVal && cnpjVal === normalize(empresa.cnpj);
+      const sameNome =
+        empresa.nome &&
+        nomeVal &&
+        nomeVal.toLowerCase() === normalize(empresa.nome).toLowerCase();
+      return sameCnpj || sameNome;
     });
+
     if (duplicate) {
       return res.status(200).json({ duplicate: true });
     }
   } catch (err) {
     console.error('Erro ao verificar duplicidade:', err);
+    // segue o fluxo mesmo assim
   }
 
-  // enriquecer dados
-  empresa = await enrichCompanyData(empresa);
+  // 2) Site por e-mail (fallback): se não veio site, tentar derivar pelo domínio corporativo
+  if (!norm(empresa.site) && norm(empresa.nome)) {
+    try {
+      const derived = await tryDeriveSiteFromMainSheet(empresa.nome);
+      if (derived) empresa.site = derived;
+    } catch (_) {}
+  }
 
+  // 3) DDI vazio se não houver telefone
+  if (!norm(empresa.telefone) && !norm(empresa.telefone2)) {
+    empresa.ddi = '';
+  }
+
+  // 4) Enriquecer dados COM AI só se NÃO houver CNPJ
+  try {
+    if (!norm(empresa.cnpj) && typeof enrichCompanyData === 'function') {
+      empresa = await enrichCompanyData(empresa);
+    }
+  } catch (err) {
+    console.error('Falha ao enriquecer dados com Perplexity:', err?.message || err);
+    // segue com o que temos
+  }
+
+  // 5) Registrar na planilha de importação
   try {
     const appendRes = await appendCompanyImportRow(empresa);
-    const range = appendRes.data?.updates?.updatedRange || '';
+    const range = appendRes?.data?.updates?.updatedRange || '';
     const match = range.match(/!(?:[A-Z]+)(\d+):/);
     const row = match ? parseInt(match[1], 10) : undefined;
     return res.status(200).json({ row });


### PR DESCRIPTION
## Summary
- replace Perplexity integration with Brazil-focused enrichment and field sanitization
- revamp company import API to derive domains, skip DDI without phones, and call AI only when CNPJ missing

## Testing
- `npm test -- --passWithNoTests`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6896b4e4dee4832c9b38a68bfa6516ff