### PR TITLE
feat(env+encoding): centralizar envs, corrigir mojibake, rota env-check e reforço no enriquecimento

### DIFF
--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -1,0 +1,25 @@
+// lib/encoding.js
+// Corrige textos UTF-8 que chegaram como Latin-1 (mojibake típico: "SÃ£o Paulo")
+export function fixEncoding(s) {
+  if (typeof s !== 'string') return s;
+  try {
+    // Se já está correto, este passo é idempotente para casos comuns
+    return Buffer.from(s, 'latin1').toString('utf8');
+  } catch {
+    return s;
+  }
+}
+
+// Saneador simples adicional (fallback) para alguns padrões frequentes
+export function deMojibake(s = '') {
+  return s
+    .replace(/SÃ£o/g, 'São')
+    .replace(/Ã¡/g, 'á').replace(/Ã©/g, 'é').replace(/Ã­/g, 'í')
+    .replace(/Ã³/g, 'ó').replace(/Ãº/g, 'ú').replace(/Ãª/g, 'ê')
+    .replace(/Ã§/g, 'ç').replace(/Ã£/g, 'ã').replace(/Ã€/g, 'À');
+}
+
+// Aplica correção robusta
+export function normalizeText(s) {
+  return deMojibake(fixEncoding(s));
+}

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,0 +1,20 @@
+// lib/env.js
+function required(name) {
+  const v = process.env[name];
+  if (!v) throw new Error(`Env ${name} ausente`);
+  return v;
+}
+
+export const PERPLEXITY = {
+  API_KEY: required('PERPLEXITY_API_KEY'),
+  ENDPOINT: process.env.PERPLEXITY_ENDPOINT || 'https://api.perplexity.ai/chat/completions',
+  MODEL: process.env.PERPLEXITY_MODEL || 'sonar',
+  TIMEOUT_MS: Number(process.env.PERPLEXITY_TIMEOUT_MS || 10000),
+};
+
+export const GOOGLE = {
+  CLIENT_EMAIL: required('GOOGLE_CLIENT_EMAIL'),
+  // Tratar \n literais quando copiados via painel
+  PRIVATE_KEY: required('GOOGLE_PRIVATE_KEY').replace(/\\n/g, '\n'),
+  SPREADSHEET_ID: required('SPREADSHEET_ID'),
+};

--- a/pages/api/enriquecer-empresa.js
+++ b/pages/api/enriquecer-empresa.js
@@ -1,0 +1,120 @@
+// pages/api/enriquecer-empresa.js
+import { PERPLEXITY } from '@/lib/env';
+import { normalizeText } from '@/lib/encoding';
+
+export const config = { runtime: 'nodejs' };
+
+function abortSignal(timeoutMs) {
+  // Compatível com Node 18+ / Next 14
+  if (typeof AbortSignal !== 'undefined' && AbortSignal.timeout) {
+    return AbortSignal.timeout(timeoutMs);
+  }
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), timeoutMs);
+  return controller.signal;
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const payload = req.body || {};
+    const { empresa, cnpj, paisPreferencial = 'Brasil' } = payload;
+
+    if (!empresa && !cnpj) {
+      return res.status(400).json({ error: 'Informe ao menos "empresa" ou "cnpj".' });
+    }
+
+    // Prompt minimalista para teste; substitua pelo seu prompt completo conforme necessário
+    const messages = [
+      {
+        role: 'user',
+        content:
+          `Preencha dados públicos da empresa priorizando a matriz no ${paisPreferencial}. ` +
+          `Se disponível, use CNPJ como âncora. Campos: nome, site, pais, estado, cidade, ` +
+          `logradouro, numero, bairro, complemento, cep, cnpj, ddi, telefones, observacao. ` +
+          `Se telefone não existir, não preencha DDI. Para site ausente, derive domínio de e-mails ` +
+          `corporativos conhecidos (ignore provedores genéricos). Empresa: ${empresa ?? ''} | CNPJ: ${cnpj ?? ''}.`,
+      },
+    ];
+
+    const r = await fetch(PERPLEXITY.ENDPOINT, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${PERPLEXITY.API_KEY}`,
+        'Content-Type': 'application/json; charset=utf-8',
+        'Accept-Charset': 'utf-8',
+      },
+      body: JSON.stringify({
+        model: PERPLEXITY.MODEL,
+        messages,
+      }),
+      signal: abortSignal(PERPLEXITY.TIMEOUT_MS),
+    });
+
+    if (!r.ok) {
+      const text = await r.text().catch(() => null);
+      return res.status(502).json({ error: 'Perplexity request failed', details: text || r.statusText });
+    }
+
+    const json = await r.json();
+    // Estrutura comum: json.choices[0].message.content
+    const content = json?.choices?.[0]?.message?.content || '';
+    // Tente interpretar como JSON primeiro; se vier texto livre, faça um parse simples
+    let dados;
+    try {
+      dados = JSON.parse(content);
+    } catch {
+      // Fallback: tente extrair pares chave: valor por linhas
+      dados = {};
+      const lines = String(content).split('\n');
+      for (const ln of lines) {
+        const [k, ...rest] = ln.split(':');
+        if (!k || !rest.length) continue;
+        dados[k.trim().toLowerCase().replace(/\s+/g, '_')] = rest.join(':').trim();
+      }
+    }
+
+    // Normalize todos os campos de texto para evitar "SÃ£o Paulo"
+    const norm = {};
+    for (const [k, v] of Object.entries(dados)) {
+      norm[k] = typeof v === 'string' ? normalizeText(v) : v;
+    }
+
+    // Políticas específicas:
+    // 1) Se telefone vazio -> não preencher DDI
+    if (!norm.telefones_empresa && !norm.telefones && !norm.telefone) {
+      delete norm.ddi_empresa;
+      delete norm.ddi;
+    }
+
+    // 2) Campos canônicos esperados pelo seu sheet/API
+    const resposta = {
+      nome: norm.nome || norm.nome_da_empresa || empresa || '',
+      site: norm.site || norm.site_empresa || '',
+      pais: norm.pais || '',
+      estado: norm.estado || norm.uf || '',
+      cidade: norm.cidade || '',
+      logradouro: norm.logradouro || '',
+      numero: norm.numero || '',
+      bairro: norm.bairro || '',
+      complemento: norm.complemento || '',
+      cep: norm.cep || '',
+      cnpj: norm.cnpj || cnpj || '',
+      ddi: norm.ddi || norm.ddi_empresa || '',
+      telefones: norm.telefones || norm.telefones_empresa || norm.telefone || '',
+      observacao: norm.observacao || norm.observações || norm.observacoes || '',
+      raw: json, // útil para depuração; remova se não quiser retornar
+    };
+
+    // Aqui você pode integrar com sua camada Google Sheets, se desejar,
+    // usando GOOGLE creds no servidor. Exemplo (comentado):
+    // await salvarNoSheet(resposta);
+
+    return res.status(200).json({ ok: true, data: resposta });
+  } catch (e) {
+    return res.status(500).json({ error: e.message || String(e) });
+  }
+}

--- a/pages/api/env-check.js
+++ b/pages/api/env-check.js
@@ -1,0 +1,18 @@
+// pages/api/env-check.js
+export const config = { runtime: 'nodejs' };
+
+const have = (k) => Boolean(process.env[k]);
+
+export default function handler(req, res) {
+  // Não expor valores; apenas flags booleanas
+  res.status(200).json({
+    PERPLEXITY_API_KEY: have('PERPLEXITY_API_KEY'),
+    PERPLEXITY_ENDPOINT: have('PERPLEXITY_ENDPOINT'),
+    PERPLEXITY_MODEL: have('PERPLEXITY_MODEL'),
+    PERPLEXITY_TIMEOUT_MS: have('PERPLEXITY_TIMEOUT_MS'),
+    GOOGLE_CLIENT_EMAIL: have('GOOGLE_CLIENT_EMAIL'),
+    GOOGLE_PRIVATE_KEY: have('GOOGLE_PRIVATE_KEY'),
+    SPREADSHEET_ID: have('SPREADSHEET_ID'),
+    runtime: process.env.VERCEL ? 'vercel' : 'local',
+  });
+}


### PR DESCRIPTION
## Summary
- centralize env var handling for Perplexity and Google with newline fix for private key
- add encoding helpers to normalize mojibake
- add /api/env-check route and rewrite enriquecer-empresa API using new env and encoding utilities

## Testing
- `npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_689b5053e304832c91b56bf123b8c597