### PR TITLE
Fix UF normalization for Brazilian states

### DIFF
--- a/lib/perplexity.js
+++ b/lib/perplexity.js
@@ -54,8 +54,45 @@ function normalizeCEP(cep) {
   return digits.replace(/^(\d{5})(\d{3})$/, '$1-$2');
 }
 
-function normalizeUF(uf) {
-  return String(uf || '').trim().slice(0, 2).toUpperCase();
+export function normalizeUF(uf) {
+  if (!uf) return '';
+  const map = {
+    AC: 'AC', ACRE: 'AC',
+    AL: 'AL', ALAGOAS: 'AL',
+    AP: 'AP', AMAPA: 'AP',
+    AM: 'AM', AMAZONAS: 'AM',
+    BA: 'BA', BAHIA: 'BA',
+    CE: 'CE', CEARA: 'CE',
+    DF: 'DF', 'DISTRITO FEDERAL': 'DF',
+    ES: 'ES', 'ESPIRITO SANTO': 'ES',
+    GO: 'GO', GOIAS: 'GO',
+    MA: 'MA', MARANHAO: 'MA',
+    MT: 'MT', 'MATO GROSSO': 'MT',
+    MS: 'MS', 'MATO GROSSO DO SUL': 'MS',
+    MG: 'MG', 'MINAS GERAIS': 'MG',
+    PA: 'PA', PARA: 'PA',
+    PB: 'PB', PARAIBA: 'PB',
+    PR: 'PR', PARANA: 'PR',
+    PE: 'PE', PERNAMBUCO: 'PE',
+    PI: 'PI', PIAUI: 'PI',
+    RJ: 'RJ', 'RIO DE JANEIRO': 'RJ',
+    RN: 'RN', 'RIO GRANDE DO NORTE': 'RN',
+    RS: 'RS', 'RIO GRANDE DO SUL': 'RS',
+    RO: 'RO', RONDONIA: 'RO',
+    RR: 'RR', RORAIMA: 'RR',
+    SC: 'SC', 'SANTA CATARINA': 'SC',
+    SP: 'SP', 'SAO PAULO': 'SP',
+    SE: 'SE', SERGIPE: 'SE',
+    TO: 'TO', TOCANTINS: 'TO',
+  };
+
+  const cleaned = String(uf)
+    .trim()
+    .toUpperCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
+
+  return map[cleaned] || '';
 }
 
 function normalizeSite(site) {


### PR DESCRIPTION
## Summary
- ensure UF normalization maps Brazilian state names to official abbreviations

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689b5caee3dc832c9b5f2ec38d52e602