### PR TITLE
feat: merge leads via Client_ID and normalize Brazilian states

### DIFF
--- a/components/ClientCard.jsx
+++ b/components/ClientCard.jsx
@@ -201,6 +201,8 @@ export default function ClientCard({ client, onStatusChange }) {
       ? '#a3ffac'
       : color === 'red'
       ? '#ffca99'
+      : color === 'gray'
+      ? '#e5e7eb'
       : 'white';
 
   const borderLeftColor =
@@ -208,6 +210,8 @@ export default function ClientCard({ client, onStatusChange }) {
       ? '#4caf50'
       : color === 'red'
       ? '#ff7043'
+      : color === 'gray'
+      ? '#9ca3af'
       : 'transparent';
 
   return (

--- a/lib/cep.js
+++ b/lib/cep.js
@@ -1,0 +1,21 @@
+export async function lookupCep(rawCep) {
+  const digits = String(rawCep || '').replace(/\D+/g, '');
+  if (digits.length !== 8) {
+    throw new Error('CEP inválido');
+  }
+  const res = await fetch(`https://viacep.com.br/ws/${digits}/json/`);
+  if (!res.ok) {
+    throw new Error('Falha na consulta ao ViaCEP');
+  }
+  const data = await res.json();
+  if (data.erro) {
+    throw new Error('CEP não encontrado');
+  }
+  return {
+    cep: data.cep || `${digits.slice(0, 5)}-${digits.slice(5)}`,
+    logradouro: data.logradouro || '',
+    bairro: data.bairro || '',
+    localidade: data.localidade || '',
+    uf: data.uf || '',
+  };
+}

--- a/lib/googleSheets.js
+++ b/lib/googleSheets.js
@@ -89,6 +89,33 @@ async function authorize() {
   return auth;
 }
 
+// ✅ Cliente reutilizável do Google Sheets
+export async function getSheetsClient() {
+  const auth = await authorize();
+  return google.sheets({ version: 'v4', auth });
+}
+
+// ✅ Leitura genérica de abas retornando cabeçalhos e linhas como objetos
+export async function getSheetData(sheetName, spreadsheetId = process.env.SPREADSHEET_ID) {
+  const sheets = await getSheetsClient();
+  const res = await sheets.spreadsheets.values.get({
+    spreadsheetId,
+    range: `${sheetName}!A:Z`,
+    valueRenderOption: 'UNFORMATTED_VALUE',
+  });
+  const rows = res.data.values || [];
+  if (!rows.length) return { headers: [], rows: [] };
+  const headers = rows[0];
+  const data = rows.slice(1).map((row, idx) => {
+    const obj = { _rowNumber: idx + 2 };
+    headers.forEach((h, i) => {
+      obj[h] = row[i] ?? '';
+    });
+    return obj;
+  });
+  return { headers, rows: data };
+}
+
 function columnToLetter(index) {
   let letter = '';
   let temp = index;

--- a/lib/perplexity.js
+++ b/lib/perplexity.js
@@ -1,3 +1,5 @@
+import { lookupCep } from './cep.js';
+
 const DEFAULT_ENDPOINT = 'https://api.perplexity.ai/chat/completions';
 const DEFAULT_MODEL = 'sonar';
 const DEFAULT_TIMEOUT = 10000;
@@ -54,8 +56,45 @@ function normalizeCEP(cep) {
   return digits.replace(/^(\d{5})(\d{3})$/, '$1-$2');
 }
 
-function normalizeUF(uf) {
-  return String(uf || '').trim().slice(0, 2).toUpperCase();
+export function normalizeUF(uf) {
+  if (!uf) return '';
+  const map = {
+    AC: 'AC', ACRE: 'AC',
+    AL: 'AL', ALAGOAS: 'AL',
+    AP: 'AP', AMAPA: 'AP',
+    AM: 'AM', AMAZONAS: 'AM',
+    BA: 'BA', BAHIA: 'BA',
+    CE: 'CE', CEARA: 'CE',
+    DF: 'DF', 'DISTRITO FEDERAL': 'DF',
+    ES: 'ES', 'ESPIRITO SANTO': 'ES',
+    GO: 'GO', GOIAS: 'GO',
+    MA: 'MA', MARANHAO: 'MA',
+    MT: 'MT', 'MATO GROSSO': 'MT',
+    MS: 'MS', 'MATO GROSSO DO SUL': 'MS',
+    MG: 'MG', 'MINAS GERAIS': 'MG',
+    PA: 'PA', PARA: 'PA',
+    PB: 'PB', PARAIBA: 'PB',
+    PR: 'PR', PARANA: 'PR',
+    PE: 'PE', PERNAMBUCO: 'PE',
+    PI: 'PI', PIAUI: 'PI',
+    RJ: 'RJ', 'RIO DE JANEIRO': 'RJ',
+    RN: 'RN', 'RIO GRANDE DO NORTE': 'RN',
+    RS: 'RS', 'RIO GRANDE DO SUL': 'RS',
+    RO: 'RO', RONDONIA: 'RO',
+    RR: 'RR', RORAIMA: 'RR',
+    SC: 'SC', 'SANTA CATARINA': 'SC',
+    SP: 'SP', 'SAO PAULO': 'SP',
+    SE: 'SE', SERGIPE: 'SE',
+    TO: 'TO', TOCANTINS: 'TO',
+  };
+
+  const cleaned = String(uf)
+    .trim()
+    .toUpperCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
+
+  return map[cleaned] || '';
 }
 
 function normalizeSite(site) {
@@ -91,12 +130,56 @@ function parsePhones(value) {
   return phones;
 }
 
+function normalizeEmpty(value) {
+  const cleaned = String(value || '')
+    .trim()
+    .replace(/[\[\]]/g, '')
+    .toUpperCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
+  const invalid = new Set([
+    '',
+    'NAO',
+    'NAO INFORMADO',
+    'NAO ESPECIFICADO',
+    'SEM DADOS',
+    'NAO POSSUI',
+    'NAO TEM',
+    'N/A',
+    'NA',
+    'NULL',
+    '-',
+    'NAO ENCONTRADO',
+    'NAO EXISTENTE',
+    'N/D',
+    'ND',
+  ]);
+  return invalid.has(cleaned) ? '' : String(value).trim();
+}
+
 function sanitize(data) {
   const out = { ...data };
-  out.pais = 'Brasil';
+  Object.keys(out).forEach((k) => {
+    if (typeof out[k] === 'string') out[k] = normalizeEmpty(out[k]);
+  });
+  const country = String(out.pais || '')
+    .trim()
+    .toUpperCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '');
   out.estado = normalizeUF(out.estado);
   out.cep = normalizeCEP(out.cep);
   out.cnpj = normalizeCNPJ(out.cnpj);
+  if (!['BRASIL', 'BRAZIL'].includes(country) || !out.estado) {
+    out.cidade = '';
+    out.logradouro = '';
+    out.numero = '';
+    out.bairro = '';
+    out.complemento = '';
+    out.cep = '';
+    out.estado = '';
+  }
+  out.pais = 'Brasil';
   const phones = parsePhones(out.telefone);
   out.telefone = normalizePhone(phones[0]);
   out.telefone2 = normalizePhone(phones[1]);
@@ -163,9 +246,11 @@ export async function enrichCompanyData(empresa) {
     return sanitized;
   }
 
-  const queryParts = [empresa?.nome, empresa?.cidade, empresa?.estado].filter(Boolean).join(', ');
+  const queryParts = [empresa?.nome, empresa?.cidade, empresa?.estado, 'Brasil']
+    .filter(Boolean)
+    .join(', ');
 
-  const tablePrompt = `Considere a empresa ${queryParts}. Retorne uma tabela Markdown com as colunas: Nome da Empresa | Site Empresa | País Empresa | Estado Empresa | Cidade Empresa | Logradouro Empresa | Número Empresa | Bairro Empresa | Complemento Empresa | CEP Empresa | CNPJ Empresa | DDI Empresa | Telefones Empresa | Observação Empresa. A resposta deve ser apenas a tabela, sem nenhum texto adicional.`;
+  const tablePrompt = `Considere a empresa ${queryParts} e forneça os dados da sua sede no Brasil. Retorne uma tabela Markdown com as colunas: Nome da Empresa | Site Empresa | País Empresa | Estado Empresa | Cidade Empresa | Logradouro Empresa | Número Empresa | Bairro Empresa | Complemento Empresa | CEP Empresa | CNPJ Empresa | DDI Empresa | Telefones Empresa | Observação Empresa. Use apenas informações do endereço no Brasil e ignore matrizes ou filiais no exterior. A resposta deve ser apenas a tabela, sem nenhum texto adicional.`;
   let tableText = '';
   try {
     tableText = await callPerplexity(tablePrompt, timeout, endpoint, model, apiKey);
@@ -176,7 +261,7 @@ export async function enrichCompanyData(empresa) {
   let enriched = mapFromTable(tableObj);
 
   if (!normalizeCNPJ(enriched.cnpj)) {
-    const cnpjPrompt = `Forneça apenas o CNPJ da empresa ${queryParts} da matriz 0001 no formato { "cnpj": "00.000.000/0001-00" }. A resposta deve ser apenas esse JSON.`;
+    const cnpjPrompt = `Forneça apenas o CNPJ da empresa ${queryParts} da matriz 0001 no Brasil no formato { "cnpj": "00.000.000/0001-00" }. A resposta deve ser apenas esse JSON.`;
     let cnpjText = '';
     try {
       cnpjText = await callPerplexity(cnpjPrompt, timeout, endpoint, model, apiKey);
@@ -199,6 +284,26 @@ export async function enrichCompanyData(empresa) {
   enriched.nome = enriched.nome || empresa?.nome || '';
   enriched.estado = enriched.estado || empresa?.estado || '';
   enriched.cidade = enriched.cidade || empresa?.cidade || '';
+  enriched.cep = enriched.cep || empresa?.cep || '';
+
+  enriched.cep = normalizeEmpty(enriched.cep);
+  ['logradouro', 'bairro', 'cidade', 'estado', 'complemento'].forEach(
+    (k) => (enriched[k] = normalizeEmpty(enriched[k]))
+  );
+
+  // Se houver CEP válido, prioriza o uso do ViaCEP para preencher endereço
+  if (enriched.cep) {
+    try {
+      const viaCepData = await lookupCep(enriched.cep);
+      enriched.cep = viaCepData.cep;
+      enriched.logradouro = viaCepData.logradouro;
+      enriched.bairro = viaCepData.bairro;
+      enriched.cidade = viaCepData.localidade;
+      enriched.estado = viaCepData.uf;
+    } catch {
+      // ignora falhas na consulta ao ViaCEP
+    }
+  }
 
   return sanitize(enriched);
 }

--- a/pages/api/cep.js
+++ b/pages/api/cep.js
@@ -1,0 +1,14 @@
+import { lookupCep } from '../../lib/cep.js';
+
+export default async function handler(req, res) {
+  const cep = req.method === 'GET' ? req.query.cep : req.body?.cep;
+  if (!cep) {
+    return res.status(400).json({ ok: false, error: 'CEP é obrigatório' });
+  }
+  try {
+    const data = await lookupCep(cep);
+    return res.status(200).json({ ok: true, data });
+  } catch (err) {
+    return res.status(400).json({ ok: false, error: String(err?.message || err) });
+  }
+}

--- a/pages/api/enriquecer-empresa.js
+++ b/pages/api/enriquecer-empresa.js
@@ -4,8 +4,19 @@ import { enrichCompanyData } from '../../lib/perplexity.js';
 
 const SHEET_NAME = 'layout_importacao_empresas';
 
+// Normaliza cabeçalhos removendo acentos, espaços extras e case
+function normalizeHeader(h) {
+  return (h || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
 // Ordem exata das colunas na planilha:
 const HEADERS = [
+  'Cliente_ID',
   'Nome da Empresa',
   'Site Empresa',
   'País Empresa',
@@ -22,12 +33,16 @@ const HEADERS = [
   'Observação Empresa'
 ];
 
-function mapToRow(enriched) {
+// Versões normalizadas para comparações flexíveis
+const NORMALIZED_HEADERS = HEADERS.map(normalizeHeader);
+
+function mapToRow(enriched, clienteId) {
   // Garantir strings simples sem undefined
   const g = (v) => (v == null ? '' : String(v).trim());
 
   // Compatibilizar chaves internas da lib com os headers
   return [
+    g(clienteId),
     g(enriched.nome),
     g(enriched.site),
     g(enriched.pais || 'Brasil'),
@@ -76,46 +91,103 @@ async function getAllRows(sheets, spreadsheetId) {
 }
 
 function getColumnIndex(headers, name) {
-  return headers.findIndex((h) => h.toLowerCase() === name.toLowerCase());
+  const target = normalizeHeader(name);
+  return headers.findIndex((h) => normalizeHeader(h) === target);
 }
 
-function normalizeCNPJ(cnpj) {
-  if (!cnpj) return '';
-  const digits = String(cnpj).replace(/\D+/g, '');
-  if (digits.length !== 14) return '';
-  return digits.replace(/^(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})$/, '$1.$2.$3/$4-$5');
-}
-
-async function getRowIndexByCNPJ(sheets, spreadsheetId, headers, cnpj) {
-  const cnpjIdx = getColumnIndex(headers, 'CNPJ Empresa');
-  if (cnpjIdx < 0) return -1;
+async function getRowIndexByClientId(sheets, spreadsheetId, headers, clientId) {
+  const idIdx = getColumnIndex(headers, 'Cliente_ID');
+  if (idIdx < 0) return -1;
   const rows = await getAllRows(sheets, spreadsheetId);
-  const fixed = normalizeCNPJ(cnpj);
-  if (!fixed) return -1;
-
   for (let i = 0; i < rows.length; i++) {
-    const rowCnpj = normalizeCNPJ(rows[i]?.[cnpjIdx] || '');
-    if (rowCnpj && rowCnpj === fixed) {
-      // +2 porque rows começa em A2 (linha 2); i=0 => linha 2
-      return i + 2;
+    if ((rows[i]?.[idIdx] || '').toString() === (clientId || '').toString()) {
+      return i + 2; // +2 porque rows começa em A2
     }
   }
   return -1;
 }
 
-async function upsertCompany(sheets, spreadsheetId, headers, rowValues) {
-  // headers devem bater 1:1 com HEADERS
-  if (headers.length !== HEADERS.length) {
-    throw new Error(`Headers da planilha não batem com o esperado. Esperado: ${HEADERS.join(' | ')}`);
+const FREE_EMAIL_DOMAINS = new Set([
+  'gmail.com',
+  'gmail.com.br',
+  'hotmail.com',
+  'hotmail.com.br',
+  'outlook.com',
+  'outlook.com.br',
+  'live.com',
+  'yahoo.com',
+  'yahoo.com.br',
+  'bol.com.br',
+  'uol.com.br',
+  'icloud.com',
+  'msn.com',
+  'aol.com',
+  'terra.com.br',
+]);
+
+function extractDomain(email) {
+  const match = String(email || '')
+    .toLowerCase()
+    .match(/@([^\s@]+)/);
+  if (!match) return '';
+  const domain = match[1];
+  if (FREE_EMAIL_DOMAINS.has(domain)) return '';
+  return domain;
+}
+
+async function findDomainFromSheet1(sheets, spreadsheetId, clientId) {
+  try {
+    const res = await sheets.spreadsheets.values.get({
+      spreadsheetId,
+      range: 'Sheet1!A:Z',
+      valueRenderOption: 'UNFORMATTED_VALUE',
+    });
+    const rows = res.data.values || [];
+    if (!rows.length) return '';
+    const headers = rows[0];
+    const idIdx = headers.indexOf('Cliente_ID');
+    if (idIdx < 0) return '';
+    const workIdx = headers.indexOf('Pessoa - Email - Work');
+    const homeIdx = headers.indexOf('Pessoa - Email - Home');
+    const otherIdx = headers.indexOf('Pessoa - Email - Other');
+    for (let i = 1; i < rows.length; i++) {
+      const row = rows[i];
+      if ((row[idIdx] || '').toString() !== (clientId || '').toString()) continue;
+      const emails = [];
+      [workIdx, homeIdx, otherIdx].forEach((idx) => {
+        if (idx >= 0 && row[idx]) emails.push(row[idx]);
+      });
+      for (const email of emails) {
+        const domain = extractDomain(email);
+        if (domain) return domain;
+      }
+      break;
+    }
+  } catch {}
+  return '';
+}
+
+async function upsertCompany(sheets, spreadsheetId, headers, rowValues, overwrite) {
+  // headers devem bater 1:1 com HEADERS (normalizados)
+  const normalized = headers.map(normalizeHeader);
+  if (
+    normalized.length !== NORMALIZED_HEADERS.length ||
+    normalized.some((h, i) => h !== NORMALIZED_HEADERS[i])
+  ) {
+    throw new Error(
+      `Headers da planilha não batem com o esperado. Esperado: ${HEADERS.join(' | ')}`
+    );
   }
 
-  const cnpjIdx = getColumnIndex(headers, 'CNPJ Empresa');
-  const cnpjValue = rowValues[cnpjIdx] || '';
-  const rowIndex = await getRowIndexByCNPJ(sheets, spreadsheetId, headers, cnpjValue);
+  const idIdx = getColumnIndex(headers, 'Cliente_ID');
+  const clientId = rowValues[idIdx] || '';
+  const rowIndex = await getRowIndexByClientId(sheets, spreadsheetId, headers, clientId);
 
   if (rowIndex > 0) {
-    // Update linha existente
-    const range = `${SHEET_NAME}!A${rowIndex}:N${rowIndex}`;
+    if (!overwrite) {
+      return { action: 'exists', rowIndex };
+    }
+    const range = `${SHEET_NAME}!A${rowIndex}:O${rowIndex}`; // 15 colunas => até O
     await sheets.spreadsheets.values.update({
       spreadsheetId,
       range,
@@ -124,8 +196,7 @@ async function upsertCompany(sheets, spreadsheetId, headers, rowValues) {
     });
     return { action: 'updated', rowIndex };
   } else {
-    // Append no final
-    const range = `${SHEET_NAME}!A:N`;
+    const range = `${SHEET_NAME}!A:O`;
     await sheets.spreadsheets.values.append({
       spreadsheetId,
       range,
@@ -143,26 +214,33 @@ export default async function handler(req, res) {
   }
 
   try {
-    const { clienteId, nome, estado, cidade } = req.body || {};
+    const { clienteId, nome, estado, cidade, cep, overwrite } = req.body || {};
     if (!nome) {
       return res.status(400).json({ ok: false, error: 'Nome é obrigatório' });
     }
 
     // 1) Enriquecer com Perplexity
-    const enriched = await enrichCompanyData({ nome, estado, cidade });
+    const enriched = await enrichCompanyData({ nome, estado, cidade, cep });
 
-    // 2) Mapear para a linha no formato exato da planilha
-    const rowValues = mapToRow(enriched);
-
-    // 3) Persistir (upsert) na planilha
+    // 1.1) Se site ausente, tentar derivar do domínio de e-mail da Sheet1
     const sheets = await getSheetsClient();
     const spreadsheetId = process.env.SPREADSHEET_ID;
+    if (!enriched.site && clienteId) {
+      const domain = await findDomainFromSheet1(sheets, spreadsheetId, clienteId);
+      if (domain) enriched.site = `www.${domain}`;
+    }
+
+    // 2) Mapear para a linha no formato exato da planilha
+    const rowValues = mapToRow(enriched, clienteId);
+
+    // 3) Persistir (upsert) na planilha
     const headers = await getHeaderRow(sheets, spreadsheetId);
 
-    // Validação rápida de cabeçalho (ordem e nomes)
+    // Validação rápida de cabeçalho (ordem e nomes, normalizados)
+    const normalized = headers.map(normalizeHeader);
     const mismatch =
-      headers.length !== HEADERS.length ||
-      headers.some((h, i) => (h || '').trim() !== HEADERS[i]);
+      normalized.length !== NORMALIZED_HEADERS.length ||
+      normalized.some((h, i) => h !== NORMALIZED_HEADERS[i]);
     if (mismatch) {
       return res.status(412).json({
         ok: false,
@@ -172,7 +250,11 @@ export default async function handler(req, res) {
       });
     }
 
-    const result = await upsertCompany(sheets, spreadsheetId, headers, rowValues);
+    const result = await upsertCompany(sheets, spreadsheetId, headers, rowValues, overwrite);
+
+    if (result.action === 'exists' && !overwrite) {
+      return res.status(200).json({ ok: false, exists: true });
+    }
 
     return res.status(200).json({ ok: true, data: { enriched, result } });
   } catch (error) {

--- a/pages/api/mesclar-leads-exact-spotter.js
+++ b/pages/api/mesclar-leads-exact-spotter.js
@@ -1,0 +1,308 @@
+import { getSheetsClient, getSheetData } from '../../lib/googleSheets';
+
+const SHEET_LAYOUT = 'layout_importacao_empresas';
+const SHEET_SHEET1 = 'Sheet1';
+const SHEET_PADROES = 'Padroes';
+const SHEET_DEST = 'Leads Exact Spotter';
+const DEST_KEY = 'Client_ID'; // chave única padronizada
+
+// Utils
+const clean = (v) => (v ?? '').toString().trim();
+const pick = (row, ...names) => {
+  for (const n of names) {
+    const v = row[n];
+    if (v !== undefined && v !== null && clean(v)) return clean(v);
+  }
+  return '';
+};
+
+function normalizeUF(uf) {
+  const norm = clean(uf)
+    .toUpperCase()
+    .normalize('NFD')
+    .replace(/[^A-Z]/g, '');
+  const map = {
+    AC: 'AC', ACRE: 'AC',
+    AL: 'AL', ALAGOAS: 'AL',
+    AP: 'AP', AMAPA: 'AP',
+    AM: 'AM', AMAZONAS: 'AM',
+    BA: 'BA', BAHIA: 'BA',
+    CE: 'CE', CEARA: 'CE', CEARÁ: 'CE',
+    DF: 'DF', DISTRITOFEDERAL: 'DF',
+    ES: 'ES', ESPIRITOSANTO: 'ES', ESPÍRITOSANTO: 'ES',
+    GO: 'GO', GOIAS: 'GO', GOIÁS: 'GO',
+    MA: 'MA', MARANHAO: 'MA', MARANHÃO: 'MA',
+    MT: 'MT', MATOGROSSO: 'MT',
+    MS: 'MS', MATOGROSSODOSUL: 'MS',
+    MG: 'MG', MINASGERAIS: 'MG',
+    PA: 'PA', PARA: 'PA', PARÁ: 'PA',
+    PB: 'PB', PARAIBA: 'PB', PARAÍBA: 'PB',
+    PR: 'PR', PARANA: 'PR', PARANÁ: 'PR',
+    PE: 'PE', PERNAMBUCO: 'PE',
+    PI: 'PI', PIAUI: 'PI', PIAUÍ: 'PI',
+    RJ: 'RJ', RIODEJANEIRO: 'RJ',
+    RN: 'RN', RIOGRANDEDONORTE: 'RN',
+    RS: 'RS', RIOGRANDEDOSUL: 'RS',
+    RO: 'RO', RONDONIA: 'RO', RONDÔNIA: 'RO',
+    RR: 'RR', RORAIMA: 'RR',
+    SC: 'SC', SANTACATARINA: 'SC',
+    SP: 'SP', SAOPAULO: 'SP',
+    SE: 'SE', SERGIPE: 'SE',
+    TO: 'TO', TOCANTINS: 'TO'
+  };
+  return map[norm] || norm;
+}
+function splitPhones(str) {
+  if (!str) return [];
+  return [...new Set(
+    str.split(';').map(s => clean(s)).filter(Boolean)
+  )];
+}
+function joinPhones(arr) {
+  return (arr && arr.length) ? arr.join(';') : '';
+}
+function preferNonEmpty(curr, next) {
+  return clean(next) || clean(curr) || '';
+}
+// A -> Z -> AA...
+function colLetter(n) {
+  let s = '';
+  while (n >= 0) {
+    s = String.fromCharCode((n % 26) + 65) + s;
+    n = Math.floor(n / 26) - 1;
+  }
+  return s;
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    // 1) Ler abas com helpers do lib
+    const [{ rows: layout }, { rows: sheet1 }, { rows: padroes }, destRaw] = await Promise.all([
+      getSheetData(SHEET_LAYOUT),
+      getSheetData(SHEET_SHEET1),
+      getSheetData(SHEET_PADROES),
+      getSheetData(SHEET_DEST),
+    ]);
+
+    const { headers: destHeadersRaw, rows: destRows } = destRaw;
+
+    // 2) Listas válidas de Produtos e Mercados
+    const produtosValidos = padroes.map(r => clean(r['Produtos'])).filter(Boolean);
+    const mercadosValidos = padroes.map(r => clean(r['Mercados'])).filter(Boolean);
+
+    // 3) Índices por Client_ID (tolerando Cliente_ID)
+    const idOf = (r) => clean(r[DEST_KEY] || r['Cliente_ID']);
+    const mapSheet1 = new Map(sheet1.map(r => [idOf(r), r]).filter(([k]) => !!k));
+    const mapDest = new Map(destRows.map(r => [idOf(r), r]).filter(([k]) => !!k));
+
+    // 4) Header do destino (migrar Cliente_ID -> Client_ID se necessário)
+    const neededCols = new Set([
+      DEST_KEY,
+      'Nome do Lead','Origem','Sub-Origem','Mercado','Produto',
+      'Site','País','Estado','Cidade','Logradouro','Número','Bairro','Complemento','CEP',
+      'DDI','Telefones',
+      'Observação','CPF/CNPJ',
+      'Nome Contato','E-mail Contato','Cargo Contato','DDI Contato','Telefones Contato',
+      'Tipo do Serv. Comunicação','ID do Serv. Comunicação','Área',
+      'Nome da Empresa','Etapa','Funil',
+    ]);
+
+    let header = Array.isArray(destHeadersRaw) ? [...destHeadersRaw] : [];
+    const hasOld = header.includes('Cliente_ID');
+    const hasNew = header.includes(DEST_KEY);
+    if (hasOld && !hasNew) {
+      header = header.map(h => (h === 'Cliente_ID' ? DEST_KEY : h));
+    }
+    if (!header.includes(DEST_KEY)) header.unshift(DEST_KEY);
+    for (const c of neededCols) {
+      if (!header.includes(c)) header.push(c);
+    }
+
+    const sheets = await getSheetsClient();
+    const headerChanged = !destHeadersRaw
+      || header.length !== destHeadersRaw.length
+      || header.some((h, i) => h !== destHeadersRaw[i]);
+
+    if (headerChanged) {
+      await sheets.spreadsheets.values.update({
+        spreadsheetId: process.env.SPREADSHEET_ID,
+        range: `${SHEET_DEST}!1:1`,
+        valueInputOption: 'RAW',
+        requestBody: { values: [header] },
+      });
+    }
+    const endCol = colLetter(header.length - 1);
+
+    // 5) Preparar upserts
+    const updates = [];
+    const appends = [];
+    let created = 0, updated = 0, ignoradasSemId = 0, ignoradasSemBase = 0;
+    const errosObrigatorios = [];
+
+    for (const row of layout) {
+      const id = idOf(row);
+      if (!id) { ignoradasSemId++; continue; }
+
+      const base = mapSheet1.get(id);
+      if (!base) { ignoradasSemBase++; continue; }
+
+      const atual = mapDest.get(id) || {};
+
+      // Nome da Empresa
+      const nomeEmpresa = pick(row, 'Nome da Empresa') || clean(atual['Nome da Empresa']);
+
+      // Produto (pode não existir na layout; só aceita se ∈ Padroes/Produtos)
+      const produtoInput = pick(row, 'Produto'); // se não existir, virá vazio
+      const produto = produtosValidos.includes(produtoInput) ? produtoInput : clean(atual['Produto']);
+
+      // Nome do Lead
+      const nomeLead = produto ? `${nomeEmpresa} - ${produto}` : `${nomeEmpresa}`;
+
+      // Mercado (Sheet1 -> Organização - Segmento)
+      const segmento = clean(base['Organização - Segmento']);
+      const mercado = segmento && mercadosValidos.includes(segmento) ? segmento : 'N/A';
+
+      // Site (remover barras finais)
+      const rawSite = pick(row, 'Site Empresa');
+      const site = rawSite.replace(/\/+$/, '');
+
+      // Endereço vindo da layout
+      const estado = normalizeUF(pick(row, 'Estado Empresa'));
+      const cidade = pick(row, 'Cidade Empresa');
+      const logradouro = pick(row, 'Logradouro Empresa');
+      const numero = pick(row, 'Numero Empresa', 'Número Empresa');
+      const bairro = pick(row, 'Bairro Empresa');
+      const complemento = pick(row, 'Complemento Empresa');
+      const cep = pick(row, 'CEP Empresa');
+
+      // País: preferir “País Empresa” (ou “Pais Empresa”); se faltar e houver cidade+estado, usar "Brasil"
+      const pais = pick(row, 'País Empresa', 'Pais Empresa') || ((cidade && estado) ? 'Brasil' : '');
+
+      // Telefones (prioridade: Card -> layout -> Sheet1)
+      const telsCard = splitPhones(pick(row, 'Telefones Card')); // pode não existir
+      const telsLayout = splitPhones(pick(row, 'Telefones Empresa'));
+      const telSheet1 = splitPhones(base['Telefone Normalizado']);
+      const telefones = telsCard.length ? telsCard : (telsLayout.length ? telsLayout : telSheet1);
+      const telefonesStr = joinPhones(telefones);
+
+      // DDI apenas se houver algum telefone
+      const ddi = telefones.length ? pick(row, 'DDI Empresa', 'DDI') : '';
+
+      // Observação (não herdar se vazio)
+      const observacao = pick(row, 'Observação Empresa', 'Observação');
+
+      // CPF/CNPJ
+      const cnpj = pick(row, 'CNPJ Empresa');
+
+      // Contatos (Card) — podem não existir na layout
+      const nomeContato = pick(row, 'Nome Contato');
+      const emailContato = pick(row, 'E-mail Contato', 'Email Contato');
+      const cargoContato = pick(row, 'Cargo Contato');
+      const telsContato = splitPhones(pick(row, 'Telefones Contato'));
+      const ddiContato = telsContato.length ? pick(row, 'DDI Contato') : '';
+      const algumContatoPreenchido = !!(nomeContato || emailContato || cargoContato || telsContato.length);
+      if (algumContatoPreenchido && !nomeContato) {
+        errosObrigatorios.push({ [DEST_KEY]: id, erro: 'Nome Contato obrigatório quando houver outros campos de contato' });
+      }
+
+      // Monta objeto final com política "não sobrescrever com vazio"
+      const novo = {
+        [DEST_KEY]: id,
+
+        'Nome do Lead': preferNonEmpty(atual['Nome do Lead'], nomeLead),
+        'Origem': 'Carteira de Clientes',
+        'Sub-Origem': '',
+
+        'Mercado': preferNonEmpty(atual['Mercado'], mercado),
+        'Produto': preferNonEmpty(atual['Produto'], produto),
+
+        'Site': preferNonEmpty(atual['Site'], site),
+
+        'País': preferNonEmpty(atual['País'], pais),
+        'Estado': preferNonEmpty(atual['Estado'], estado),
+        'Cidade': preferNonEmpty(atual['Cidade'], cidade),
+        'Logradouro': preferNonEmpty(atual['Logradouro'], logradouro),
+        'Número': preferNonEmpty(atual['Número'], numero),
+        'Bairro': preferNonEmpty(atual['Bairro'], bairro),
+        'Complemento': preferNonEmpty(atual['Complemento'], complemento),
+        'CEP': preferNonEmpty(atual['CEP'], cep),
+
+        'DDI': preferNonEmpty(atual['DDI'], ddi),
+        'Telefones': preferNonEmpty(atual['Telefones'], telefonesStr),
+
+        'Observação': observacao || clean(atual['Observação']),
+
+        'CPF/CNPJ': preferNonEmpty(atual['CPF/CNPJ'], cnpj),
+
+        'Nome Contato': preferNonEmpty(atual['Nome Contato'], nomeContato),
+        'E-mail Contato': preferNonEmpty(atual['E-mail Contato'], emailContato),
+        'Cargo Contato': preferNonEmpty(atual['Cargo Contato'], cargoContato),
+        'DDI Contato': preferNonEmpty(atual['DDI Contato'], ddiContato),
+        'Telefones Contato': preferNonEmpty(atual['Telefones Contato'], joinPhones(telsContato)),
+
+        'Tipo do Serv. Comunicação': '',
+        'ID do Serv. Comunicação': '',
+        'Área': '',
+
+        'Nome da Empresa': preferNonEmpty(atual['Nome da Empresa'], nomeEmpresa),
+        'Etapa': 'Agendados',
+        'Funil': 'Padrão',
+      };
+
+      const rowValues = header.map(col => (novo[col] ?? '').toString());
+
+      const exists = mapDest.get(id);
+      if (exists && exists._rowNumber) {
+        const rowIndex = exists._rowNumber;
+        updates.push({
+          range: `${SHEET_DEST}!A${rowIndex}:${endCol}${rowIndex}`,
+          values: [rowValues],
+        });
+        updated++;
+      } else {
+        appends.push(rowValues);
+        created++;
+      }
+    }
+
+    // 6) Writes
+    if (updates.length > 0) {
+      await sheets.spreadsheets.values.batchUpdate({
+        spreadsheetId: process.env.SPREADSHEET_ID,
+        requestBody: {
+          valueInputOption: 'RAW',
+          data: updates,
+        },
+      });
+    }
+    if (appends.length > 0) {
+      await sheets.spreadsheets.values.append({
+        spreadsheetId: process.env.SPREADSHEET_ID,
+        range: `${SHEET_DEST}!A1`,
+        valueInputOption: 'RAW',
+        insertDataOption: 'INSERT_ROWS',
+        requestBody: { values: appends },
+      });
+    }
+
+    // 7) Retorno
+    const ignoradas = ignoradasSemId + ignoradasSemBase; // total ignoradas
+    return res.status(200).json({
+      criadas: created,
+      atualizadas: updated,
+      ignoradas,
+      ignoradasSemId,
+      ignoradasSemBase,
+      errosObrigatorios,
+    });
+
+  } catch (err) {
+    console.error('[mesclar-leads-exact-spotter] ERRO:', err);
+    return res.status(500).json({ error: err.message });
+  }
+}
+

--- a/pages/api/padroes.js
+++ b/pages/api/padroes.js
@@ -1,0 +1,13 @@
+import { getSheetData } from '../../lib/googleSheets';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return res.status(405).end();
+  try {
+    const { rows } = await getSheetData('Padroes');
+    const produtos = Array.from(new Set(rows.map(r => r.Produtos).filter(Boolean)));
+    const mercados = Array.from(new Set(rows.map(r => r.Mercados).filter(Boolean)));
+    res.status(200).json({ produtos, mercados });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}


### PR DESCRIPTION
## Summary
- add mesclar-leads-exact-spotter API to merge layout_importacao_empresas and Sheet1 into Leads Exact Spotter using Client_ID
- migrate legacy headers and normalize UF names to official codes

## Testing
- `npm test -- --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b5caee3dc832c9b5f2ec38d52e602