### PR TITLE
Reset observation modal input on open and cancel

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['next/babel'],
+};

--- a/components/ObservationModal.jsx
+++ b/components/ObservationModal.jsx
@@ -1,8 +1,12 @@
 'use client';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 export default function ObservationModal({ open, onConfirm, onClose }) {
   const [obs, setObs] = useState('');
+
+  useEffect(() => {
+    if (open) setObs('');
+  }, [open]);
 
   if (!open) return null;
 
@@ -32,7 +36,10 @@ export default function ObservationModal({ open, onConfirm, onClose }) {
         </button>
         <button
           className="px-3 py-2 bg-gray-400 text-white rounded w-full"
-          onClick={onClose}
+          onClick={() => {
+            setObs('');
+            if (onClose) onClose();
+          }}
         >
           Cancelar
         </button>

--- a/components/ObservationModal.test.jsx
+++ b/components/ObservationModal.test.jsx
@@ -1,0 +1,25 @@
+/** @jest-environment jsdom */
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import ObservationModal from './ObservationModal';
+
+test('clears obs when opened and when cancelling', () => {
+  const handleClose = jest.fn();
+  const { rerender } = render(<ObservationModal open={false} onClose={handleClose} />);
+
+  // open modal first time
+  rerender(<ObservationModal open={true} onClose={handleClose} />);
+  const textarea = screen.getByRole('textbox');
+  fireEvent.change(textarea, { target: { value: 'test' } });
+
+  // cancel should clear value and call onClose
+  fireEvent.click(screen.getByText('Cancelar'));
+  expect(handleClose).toHaveBeenCalled();
+  expect(screen.getByRole('textbox').value).toBe('');
+
+  // close and reopen modal to ensure textarea resets
+  rerender(<ObservationModal open={false} onClose={handleClose} />);
+  rerender(<ObservationModal open={true} onClose={handleClose} />);
+  const textareaAgain = screen.getByRole('textbox');
+  expect(textareaAgain.value).toBe('');
+});


### PR DESCRIPTION
## Summary
- Clear observation field whenever modal opens or cancel is clicked
- Add Jest config and test to ensure observation input resets on open and cancel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a74f756c8c832cbc16d6e62152ae02