### PR TITLE
Reset observation text on open and cancel

### DIFF
--- a/components/ObservationModal.jsx
+++ b/components/ObservationModal.jsx
@@ -1,8 +1,12 @@
 'use client';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 export default function ObservationModal({ open, onConfirm, onClose }) {
   const [obs, setObs] = useState('');
+
+  useEffect(() => {
+    if (open) setObs('');
+  }, [open]);
 
   if (!open) return null;
 
@@ -32,7 +36,10 @@ export default function ObservationModal({ open, onConfirm, onClose }) {
         </button>
         <button
           className="px-3 py-2 bg-gray-400 text-white rounded w-full"
-          onClick={onClose}
+          onClick={() => {
+            setObs('');
+            if (onClose) onClose();
+          }}
         >
           Cancelar
         </button>

--- a/components/__tests__/ObservationModal.test.jsx
+++ b/components/__tests__/ObservationModal.test.jsx
@@ -1,0 +1,53 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ObservationModal from '../ObservationModal';
+
+describe('ObservationModal', () => {
+  test('clears input when reopened', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<ObservationModal open={false} />);
+
+    await act(async () => {
+      rerender(<ObservationModal open={true} />);
+    });
+    const textarea = screen.getByRole('textbox');
+
+    await act(async () => {
+      await user.type(textarea, 'note');
+    });
+    expect(textarea.value).toBe('note');
+
+    await act(async () => {
+      rerender(<ObservationModal open={false} />);
+    });
+    await act(async () => {
+      rerender(<ObservationModal open={true} />);
+    });
+
+    expect(screen.getByRole('textbox').value).toBe('');
+  });
+
+  test('cancel clears input and calls onClose', async () => {
+    const onClose = jest.fn();
+    const user = userEvent.setup();
+    render(<ObservationModal open={true} onClose={onClose} />);
+
+    const textarea = screen.getByRole('textbox');
+    await act(async () => {
+      await user.type(textarea, 'something');
+    });
+    await act(async () => {
+      await user.click(screen.getByText('Cancelar'));
+    });
+
+    expect(textarea.value).toBe('');
+    expect(onClose).toHaveBeenCalled();
+  });
+});
+

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({ dir: './' });
+
+const customJestConfig = {
+  testEnvironment: 'jsdom',
+};
+
+module.exports = createJestConfig(customJestConfig);
+


### PR DESCRIPTION
## Summary
- clear observation field when modal opens
- reset observation field when cancelling the modal
- add jest configuration and tests for observation modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7ad071be4832c88e152908c897bce