### PR TITLE
Encode query parameters in client fetches

### DIFF
--- a/app/consultas/perdecomp-comparativo/page.tsx
+++ b/app/consultas/perdecomp-comparativo/page.tsx
@@ -349,7 +349,7 @@ export default function PerdecompComparativoPage() {
   const checkLastConsultation = async (cnpj: string): Promise<string | null> => {
     try {
       const c = padCNPJ14(cnpj);
-      const res = await fetch(`/api/perdecomp/verificar?cnpj=${c}`);
+      const res = await fetch(`/api/perdecomp/verificar?cnpj=${encodeURIComponent(c)}`);
       if (res.ok) {
         const { lastConsultation } = await res.json();
         return lastConsultation;

--- a/components/ClientCard.jsx
+++ b/components/ClientCard.jsx
@@ -54,7 +54,7 @@ function replacePlaceholders(template, { client, contact, phone }) {
 
 async function fetchMessages(app) {
   try {
-    const res = await fetch(`/api/mensagens?app=${app}`);
+    const res = await fetch(`/api/mensagens?app=${encodeURIComponent(app)}`);
     if (!res.ok) return [];
     const data = await res.json();
     if (Array.isArray(data)) return data;
@@ -118,7 +118,7 @@ export default function ClientCard({ client, onStatusChange }) {
   };
 
   const handleHistoryClick = async () => {
-    const res = await fetch(`/api/interacoes?clienteId=${client.id}`);
+    const res = await fetch(`/api/interacoes?clienteId=${encodeURIComponent(client.id)}`);
     const history = await res.json();
     setHistoryData(history);
     setHistoryOpen(true);

--- a/components/KanbanCard.jsx
+++ b/components/KanbanCard.jsx
@@ -46,7 +46,7 @@ function replacePlaceholders(template, { client, contact, phone }) {
 
 async function fetchMessages(app) {
   try {
-    const res = await fetch(`/api/mensagens?app=${app}`);
+    const res = await fetch(`/api/mensagens?app=${encodeURIComponent(app)}`);
     if (!res.ok) return [];
     const data = await res.json();
     if (Array.isArray(data)) return data;
@@ -89,7 +89,7 @@ export default function KanbanCard({ card, index }) {
   };
 
   const handleHistoryClick = async () => {
-    const res = await fetch(`/api/interacoes?clienteId=${client.id}`);
+    const res = await fetch(`/api/interacoes?clienteId=${encodeURIComponent(client.id)}`);
     const history = await res.json();
     setHistoryData(history);
     setHistoryOpen(true);

--- a/components/Perdecomp/Autocomplete.tsx
+++ b/components/Perdecomp/Autocomplete.tsx
@@ -43,7 +43,7 @@ const Autocomplete = ({ selectedCompany, onSelect, onClear, onNoResults, onEnric
       setIsLoading(true);
       setError(null);
       try {
-        const response = await fetch(`/api/clientes/buscar?q=${query}`);
+        const response = await fetch(`/api/clientes/buscar?q=${encodeURIComponent(query)}`);
         if (response.ok) {
           const data = await response.json();
           setResults(data);


### PR DESCRIPTION
## Summary
- URL-encode autocomplete search queries before requesting the clients API
- Encode dynamic parameters on Kanban card and client card API calls
- Safely encode CNPJ when checking PerdComp consultations

## Testing
- `npm test -- --passWithNoTests`
- `node -e 'const qs=["Cliente Teste","Empresa & Filhos","A+B/C"]; qs.forEach(q=>console.log(`/api/clientes/buscar?q=${encodeURIComponent(q)}`));'`

------
https://chatgpt.com/codex/tasks/task_e_68a7ae550054832cbb63914895b4e9db