### PR TITLE
Fix Google Sheets range calculation for Sheet1

### DIFF
--- a/lib/googleSheets.js
+++ b/lib/googleSheets.js
@@ -492,22 +492,13 @@ export async function updateInSheets(clienteId, payload) {
     const sheets = await getSheetsClient();
     const spreadsheetId = process.env.SPREADSHEET_ID;
 
-    const sheetLayouts = {
-        'Leads Exact Spotter': {
-            data: buildLeadsExactSpotterRow(payload),
-            cols: 30
-        },
-        'layout_importacao_empresas': {
-            data: buildLayoutImportacaoRow(payload),
-            cols: 15
-        },
-        'Sheet1': {
-            data: buildSheet1Row(payload),
-            cols: 21
-        },
+    const sheetBuilders = {
+        'Leads Exact Spotter': buildLeadsExactSpotterRow,
+        'layout_importacao_empresas': buildLayoutImportacaoRow,
+        'Sheet1': buildSheet1Row,
     };
 
-    for (const sheetName in sheetLayouts) {
+    for (const sheetName in sheetBuilders) {
         readCache.delete(`sheetData:${sheetName}`);
         const rowNumber = await _findRowNumberByClienteId(sheetName, clienteId);
         if (rowNumber === -1) {
@@ -515,7 +506,8 @@ export async function updateInSheets(clienteId, payload) {
             continue;
         }
 
-        const rangeEndColumn = columnNumberToLetter(sheetLayouts[sheetName].cols);
+        const rowValues = sheetBuilders[sheetName](payload);
+        const rangeEndColumn = columnNumberToLetter(rowValues.length);
         const range = `${sheetName}!A${rowNumber}:${rangeEndColumn}${rowNumber}`;
 
         await withRetry(() =>
@@ -523,7 +515,7 @@ export async function updateInSheets(clienteId, payload) {
                 spreadsheetId,
                 range,
                 valueInputOption: 'USER_ENTERED',
-                requestBody: { values: [sheetLayouts[sheetName].data] },
+                requestBody: { values: [rowValues] },
             })
         );
     }


### PR DESCRIPTION
## Summary
- compute update range dynamically to match actual column count when updating sheets

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a7e4f520b4832cb444bb9fc5f1e883