### PR TITLE
Ensure NewCompany modal loads fresh data

### DIFF
--- a/app/clientes/page.jsx
+++ b/app/clientes/page.jsx
@@ -74,7 +74,7 @@ export default function ClientesPage() {
   };
 
   const handleOpenNewCompanyModal = (initialData = {}) => {
-    setCompanyPrefill({ Nome_da_Empresa: query, ...initialData });
+    setCompanyPrefill(initialData);
     setCompanyModalOpen(true);
   };
 

--- a/components/NewCompanyModal.tsx
+++ b/components/NewCompanyModal.tsx
@@ -137,6 +137,7 @@ export default function NewCompanyModal({ isOpen, initialData, warning, enrichDe
     if (isOpen) {
       setError(null);
       setEnrichDebug(initialDebug || null);
+      setFormData(initialForm);
       if (initialData) {
         setFormData(prev => applySuggestionToForm(prev, initialData, false));
       }


### PR DESCRIPTION
## Summary
- set company prefill directly from provided data
- reset form to initial state before applying suggestions when modal opens

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68a7ed77a850832cadf430954df400e4