### PR TITLE
fix: deterministic competitor cliente id

### DIFF
--- a/RELATORIO_TECNICO.md
+++ b/RELATORIO_TECNICO.md
@@ -1,0 +1,56 @@
+# Relatório Técnico PER/DCOMP
+
+## Fluxo Geral
+1. **Consulta PER/DCOMP**  
+   - Arquivo: `app/api/infosimples/perdcomp/route.ts`  
+   - Entrada: `cnpj`, intervalo de datas, `Cliente_ID` e `Nome_da_Empresa`.  
+   - Saída: objeto JSON com dados da consulta e campos mapeados.  
+   - Escrita: atualização ou append na aba `PERDECOMP` via Google Sheets API (`values.batchUpdate` ou `values.append`).
+2. **Enriquecimento de concorrentes**  
+   - Arquivo: `lib/perplexity.ts`  
+   - Funções `findCompetitors` e `enrichCompanyData` consultam a API do Perplexity e retornam dados estruturados da empresa.  
+   - Campos mapeados: `Empresa`, `Contato` e `Comercial`.
+3. **Gravação nas abas**  
+   - Arquivo: `lib/googleSheets.js`  
+   - Funções `appendToSheets`, `appendSheetData` e `updateInSheets` escrevem nas abas `Leads Exact Spotter`, `layout_importacao_empresas`, `Sheet1` e `PERDECOMP` utilizando `values.append` ou `values.update`.
+
+## Contrato de Dados
+- **Aba PERDECOMP** (`app/api/perdecomp/salvar/route.ts`)  
+  Colunas: `Cliente_ID`, `Nome da Empresa`, `Perdcomp_ID`, `CNPJ`, `Tipo_Pedido`, `Situacao`, `Periodo_Inicio`, `Periodo_Fim`, `Valor_Total`, `Numero_Processo`, `Data_Protocolo`, `Ultima_Atualizacao`, `Quantidade_Receitas`, `Quantidade_Origens`, `Quantidade_DARFs`, `URL_Comprovante_HTML`, `URL_Comprovante_PDF`, `Data_Consulta`.
+- **Demais abas** seguem o mapeamento existente em `lib/googleSheets.js` (`buildLeadsExactSpotterRow`, `buildLayoutImportacaoRow`, `buildSheet1Row`).
+
+## Padronização do `Cliente_ID`
+- Helper: `utils/clienteId.ts`
+- Regras:  
+  ```ts
+  if (cnpj && /^\d{14}$/.test(cnpj)) return `COMP-${cnpj}`;
+  const slug = normalizarNomeEmpresa(nome);
+  return `COMP-${slug}`;
+  ```
+- `normalizarNomeEmpresa` remove acentos, pontuação e espaços, mantendo apenas `[A-Za-z0-9]` (até 40 caracteres).
+- Antes de criar novo ID, busca-se na planilha (`/api/perdecomp/verificar`) por `cnpj` ou `nome` normalizado. Se encontrado, o ID existente é reutilizado e um aviso é logado.
+
+## Pontos de Escrita
+- `appendSheetData` (`lib/googleSheets.js`): usa `values.append` com `USER_ENTERED`.
+- `updateInSheets` (`lib/googleSheets.js`): usa `values.update` com intervalo dinâmico calculado por `columnNumberToLetter`.
+- `app/api/infosimples/perdcomp/route.ts`: escreve na aba `PERDECOMP` atualizando ou inserindo linhas conforme necessidade.
+
+## Cenários de Teste
+1. **Cliente existente com `Cliente_ID` conhecido** – seleção via autocomplete reutiliza o ID e consulta última data.
+2. **Concorrente com CNPJ válido** – `Cliente_ID` gerado `COMP-<CNPJ>` e reutilizado em chamadas futuras.
+3. **Concorrente sem CNPJ** – `Cliente_ID` gerado `COMP-<NomeNormalizado>`.
+4. **Reexecução para o mesmo concorrente** – rota `/perdecomp/verificar` retorna `clienteId` existente e evita duplicidade.
+5. **CNPJ com apóstrofo** – função `padCNPJ14` remove caracteres não numéricos antes de comparar.
+
+## Riscos e Mitigações
+- **Duplicidade de registros**: busca prévia por CNPJ/nome antes de gerar novo ID.  
+- **Variação de colunas**: escrita utiliza arrays alinhados ao cabeçalho de cada aba; valores excedentes são truncados.  
+- **Campos vazios ou formatados**: normalização de CNPJ e nome garante consistência.
+
+## Alterações Realizadas
+- Novo helper `utils/clienteId.ts` para ID determinístico.  
+- Rota `/api/perdecomp/verificar` agora aceita busca por `cnpj` ou `nome` e retorna `clienteId` existente.  
+- Página `app/consultas/perdecomp-comparativo/page.tsx` usa regra determinística e reutiliza IDs existentes, logando avisos em inconsistências.
+
+## Testes Executados
+- `npm test` – sem testes definidos (`No tests found`).

--- a/app/api/perdecomp/verificar/route.ts
+++ b/app/api/perdecomp/verificar/route.ts
@@ -1,33 +1,45 @@
 import { NextResponse } from 'next/server';
 import { getSheetData } from '../../../../lib/googleSheets.js';
 import { padCNPJ14 } from '@/utils/cnpj';
+import { normalizarNomeEmpresa } from '@/utils/clienteId';
 
 const PERDECOMP_SHEET_NAME = 'PERDECOMP';
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const cnpj = searchParams.get('cnpj')?.trim();
+  const cnpjParam = searchParams.get('cnpj')?.trim();
+  const nomeParam = searchParams.get('nome')?.trim();
 
-  if (!cnpj) {
-    return NextResponse.json({ message: 'Query parameter "cnpj" is required' }, { status: 400 });
+  if (!cnpjParam && !nomeParam) {
+    return NextResponse.json(
+      { message: 'Query parameter "cnpj" or "nome" is required' },
+      { status: 400 }
+    );
   }
 
-  const cleanCnpj = padCNPJ14(cnpj);
+  const cleanCnpj = cnpjParam ? padCNPJ14(cnpjParam) : null;
+  const cleanNome = nomeParam ? normalizarNomeEmpresa(nomeParam) : null;
 
   try {
     const { rows } = await getSheetData(PERDECOMP_SHEET_NAME);
 
-    const dataForCnpj = rows.filter(row => {
-      const rowCnpj = padCNPJ14(row.CNPJ);
-      return rowCnpj === cleanCnpj;
+    const data = rows.filter(row => {
+      if (cleanCnpj) {
+        const rowCnpj = padCNPJ14(row.CNPJ);
+        return rowCnpj === cleanCnpj;
+      }
+      if (cleanNome) {
+        const rowNome = normalizarNomeEmpresa(row['Nome da Empresa'] || '');
+        return rowNome === cleanNome;
+      }
+      return false;
     });
 
-    if (dataForCnpj.length === 0) {
-      return NextResponse.json({ lastConsultation: null });
+    if (data.length === 0) {
+      return NextResponse.json({ lastConsultation: null, clienteId: null });
     }
 
-    // Find the most recent consultation date
-    const mostRecentConsultation = dataForCnpj.reduce((latest, row) => {
+    const mostRecentConsultation = data.reduce((latest, row) => {
       const currentDate = new Date(row.Data_Consulta);
       if (!latest || currentDate > new Date(latest)) {
         return row.Data_Consulta;
@@ -35,11 +47,16 @@ export async function GET(request: Request) {
       return latest;
     }, '' as string | null);
 
-    return NextResponse.json({ lastConsultation: mostRecentConsultation });
+    const clienteId = data[0]?.Cliente_ID || null;
+
+    return NextResponse.json({ lastConsultation: mostRecentConsultation, clienteId });
 
   } catch (error) {
     console.error('[API /perdecomp/verificar]', error);
     const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
-    return NextResponse.json({ message: 'Failed to verify consultation', error: errorMessage }, { status: 500 });
+    return NextResponse.json(
+      { message: 'Failed to verify consultation', error: errorMessage },
+      { status: 500 }
+    );
   }
 }

--- a/utils/clienteId.ts
+++ b/utils/clienteId.ts
@@ -1,0 +1,14 @@
+export function normalizarNomeEmpresa(nome: string) {
+  return (nome || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^A-Za-z0-9]/g, '')
+    .slice(0, 40);
+}
+
+export function gerarClienteIdDeterministico({ cnpj, nome }: { cnpj?: string; nome?: string }) {
+  const digits = (cnpj || '').replace(/\D/g, '');
+  if (digits.length === 14) return `COMP-${digits}`;
+  const slug = normalizarNomeEmpresa(nome || 'EmpresaSemNome');
+  return `COMP-${slug || 'EmpresaSemNome'}`;
+}


### PR DESCRIPTION
## Summary
- add helper to generate deterministic competitor IDs
- reuse existing IDs when available and allow consulta by name or CNPJ
- document PER/DCOMP flow and data contracts

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c97a12f4832c80192118a11f08df