### PR TITLE
Avoid NextAuth 500 with lazy handler and logging

### DIFF
--- a/app/api/auth/[...nextauth]/route.js
+++ b/app/api/auth/[...nextauth]/route.js
@@ -4,12 +4,30 @@ export const dynamic = "force-dynamic";
 import NextAuth from "next-auth";
 import authOptions from "@/lib/auth/options";
 
-const handler = NextAuth(authOptions);
+const REQUIRED_ENVS = [
+  "NEXTAUTH_SECRET",
+  "GOOGLE_CLIENT_EMAIL",
+  "GOOGLE_PRIVATE_KEY",
+  "SPREADSHEET_ID",
+];
+
+function logRequest(req) {
+  const missing = REQUIRED_ENVS.filter((k) => !process.env[k]);
+  console.log(
+    `[auth] method=${req.method} url=${req.url} runtime=${process.env.NEXT_RUNTIME || "node"} missing=${missing.join(",")}`
+  );
+}
+
+async function runAuth(req, ctx) {
+  const handler = NextAuth(authOptions);
+  return handler(req, ctx);
+}
 
 // Wrappers para que /api/auth/signin nunca exploda 500 e redirecione ao /login
 export async function GET(req, ctx) {
+  logRequest(req);
   try {
-    return await handler(req, ctx);
+    return await runAuth(req, ctx);
   } catch (e) {
     console.error("Auth GET error:", e);
     const url = new URL(req.url);
@@ -21,8 +39,9 @@ export async function GET(req, ctx) {
 }
 
 export async function POST(req, ctx) {
+  logRequest(req);
   try {
-    return await handler(req, ctx);
+    return await runAuth(req, ctx);
   } catch (e) {
     console.error("Auth POST error:", e);
     return new Response(JSON.stringify({ error: "auth_internal_error" }), {

--- a/lib/auth/options.js
+++ b/lib/auth/options.js
@@ -42,15 +42,27 @@ const authOptions = {
         try {
           const email = (creds?.email || "").trim().toLowerCase();
           const password = creds?.password || "";
-          if (!email || !password) return null;
+          const log = (...args) => {
+            if (process.env.NODE_ENV !== "production") console.log("[authorize]", ...args);
+          };
+          if (!email || !password) {
+            log("missing-credentials");
+            return null;
+          }
 
           const user = await getUserByEmail(email);
-          if (!user || user.Ativo !== "TRUE") {
+          if (!user) {
+            log("user-not-found");
+            return null;
+          }
+          if (user.Ativo !== "TRUE") {
+            log("inactive");
             return null;
           }
 
           const now = new Date();
           if (user.Bloqueado_Ate && new Date(user.Bloqueado_Ate) > now) {
+            log("blocked");
             return null;
           }
 
@@ -59,6 +71,7 @@ const authOptions = {
             await registerFailure(req, email);
             const currentAttempts = Number(user.Tentativas_Login || 0);
             await updateUserByEmail(email, { Tentativas_Login: currentAttempts + 1 });
+            log("bcrypt-compare-failed");
             return null;
           }
 


### PR DESCRIPTION
## Summary
- Log request runtime and missing envs in auth route
- Instantiate NextAuth per-request to handle missing envs gracefully
- Add categorized authorize logs for easier debugging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c62379bc90832cbd31d5444c61b874