### PR TITLE
Refine view toggle param guards

### DIFF
--- a/components/view-toggle/ViewToggle.tsx
+++ b/components/view-toggle/ViewToggle.tsx
@@ -1,38 +1,47 @@
 "use client";
-import { useEffect, useMemo } from "react";
+import { useEffect } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
-const VIEWS = ["kanban", "list", "split"];
+type View = "kanban" | "list" | "split";
 
 export default function ViewToggle() {
   const router = useRouter();
   const pathname = usePathname();
   const search = useSearchParams();
 
-  const current = search.get("view") || (typeof window !== "undefined" && localStorage.getItem("kanban_view_pref")) || "kanban";
+  // Lê o valor salvo só quando houver window
+  const ls = typeof window !== "undefined" ? localStorage.getItem("kanban_view_pref") : null;
+
+  // Normaliza a view atual (URL > localStorage > default)
+  const getCurrent = (): View => {
+    const q = search?.get("view");
+    if (q === "kanban" || q === "list" || q === "split") return q;
+    if (ls === "kanban" || ls === "list" || ls === "split") return ls;
+    return "kanban";
+  };
+  const current: View = getCurrent();
 
   useEffect(() => {
-    // persiste preferência
     if (typeof window !== "undefined") {
       localStorage.setItem("kanban_view_pref", current);
     }
   }, [current]);
 
-  const setView = (v) => {
-    const sp = new URLSearchParams(search.toString());
+  const setView = (v: View) => {
+    const sp = new URLSearchParams(search?.toString() ?? "");
     sp.set("view", v);
     router.push(`${pathname}?${sp.toString()}`, { scroll: false });
   };
 
-  const Button = ({ v, label }) => {
+  const Button = ({ v, label }: { v: View; label: string }) => {
     const active = current === v;
     return (
       <button
         onClick={() => setView(v)}
         title={label}
-        className={`rounded-md px-3 py-2 text-sm border transition
-          ${active ? "bg-neutral-100 border-neutral-300" : "bg-white hover:bg-neutral-50 border-neutral-200"}
-        `}
+        className={`rounded-md px-3 py-2 text-sm border transition ${
+          active ? "bg-neutral-100 border-neutral-300" : "bg-white hover:bg-neutral-50 border-neutral-200"
+        }`}
         aria-pressed={active}
       >
         {label}


### PR DESCRIPTION
## Summary
- guard localStorage access and search param normalization in the view toggle component
- add a literal View union type to constrain accepted values when setting the current view

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9c3d7d6f0832c85cf853587810085