### PR TITLE
Add PERDCOMP sheet management module

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "jest --coverage"
+    "test": "jest --coverage",
+    "migrate": "ts-node --project tsconfig.sheets.json src/migrate.ts"
   },
   "dependencies": {
     "@hello-pangea/dnd": "16.5.0",
@@ -35,6 +36,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.1",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "ts-node": "^10.9.2"
   }
 }

--- a/src/dicUpsert.ts
+++ b/src/dicUpsert.ts
@@ -1,0 +1,158 @@
+import { sheets_v4 } from 'googleapis';
+import {
+  DIC_CREDITOS_HEADERS,
+  DIC_NATUREZAS_HEADERS,
+  DIC_TIPOS_HEADERS
+} from './perdcompHeaders';
+import {
+  getKeyRowMap,
+  getRowRange,
+  getSheetsClient,
+  getSpreadsheetId
+} from './sheets';
+
+interface TipoInput {
+  codigo: string;
+  nome: string;
+  descricao?: string;
+  exemplo?: string;
+  fonte?: string;
+}
+
+interface NaturezaInput {
+  codigoNat: string;
+  familia: 'DCOMP' | 'REST' | 'RESSARC' | 'CANC' | 'DESCONHECIDO';
+  nome: string;
+  observacao?: string;
+  exemplo?: string;
+  fonte?: string;
+}
+
+interface CreditoInput {
+  codigoCred: string;
+  descricao: string;
+  exemplo?: string;
+  fonte?: string;
+}
+
+const SHEET_TIPOS = 'DIC_TIPOS';
+const SHEET_NATUREZAS = 'DIC_NATUREZAS';
+const SHEET_CREDITOS = 'DIC_CREDITOS';
+
+export async function upsertTipo(input: TipoInput): Promise<void> {
+  const sheets = await getSheetsClient();
+  const spreadsheetId = getSpreadsheetId();
+  const key = `TIPO:${input.codigo}`;
+  const rowValues = [
+    key,
+    '4',
+    input.codigo,
+    input.nome,
+    input.descricao ?? '',
+    input.fonte ?? '',
+    input.exemplo ?? '',
+    new Date().toISOString()
+  ];
+
+  await upsertRow({
+    sheets,
+    spreadsheetId,
+    sheetTitle: SHEET_TIPOS,
+    headers: DIC_TIPOS_HEADERS,
+    key,
+    rowValues
+  });
+}
+
+export async function upsertNatureza(input: NaturezaInput): Promise<void> {
+  const sheets = await getSheetsClient();
+  const spreadsheetId = getSpreadsheetId();
+  const key = `NAT:${input.codigoNat}`;
+  const rowValues = [
+    key,
+    '5',
+    input.codigoNat,
+    input.familia,
+    input.nome,
+    input.observacao ?? '',
+    input.fonte ?? '',
+    input.exemplo ?? '',
+    new Date().toISOString()
+  ];
+
+  await upsertRow({
+    sheets,
+    spreadsheetId,
+    sheetTitle: SHEET_NATUREZAS,
+    headers: DIC_NATUREZAS_HEADERS,
+    key,
+    rowValues
+  });
+}
+
+export async function upsertCredito(input: CreditoInput): Promise<void> {
+  const sheets = await getSheetsClient();
+  const spreadsheetId = getSpreadsheetId();
+  const key = `CRED:${input.codigoCred}`;
+  const rowValues = [
+    key,
+    '6',
+    input.codigoCred,
+    input.descricao,
+    input.fonte ?? '',
+    input.exemplo ?? '',
+    new Date().toISOString()
+  ];
+
+  await upsertRow({
+    sheets,
+    spreadsheetId,
+    sheetTitle: SHEET_CREDITOS,
+    headers: DIC_CREDITOS_HEADERS,
+    key,
+    rowValues
+  });
+}
+
+interface UpsertArgs {
+  sheets: sheets_v4.Sheets;
+  spreadsheetId: string;
+  sheetTitle: string;
+  headers: readonly string[];
+  key: string;
+  rowValues: (string | number)[];
+}
+
+async function upsertRow({
+  sheets,
+  spreadsheetId,
+  sheetTitle,
+  headers,
+  key,
+  rowValues
+}: UpsertArgs): Promise<void> {
+  const keyMap = await getKeyRowMap(sheetTitle);
+  const rowIndex = keyMap.get(key);
+
+  if (rowIndex) {
+    const range = `${sheetTitle}!${getRowRange(headers, rowIndex)}`;
+    await sheets.spreadsheets.values.update({
+      spreadsheetId,
+      range,
+      valueInputOption: 'RAW',
+      requestBody: {
+        values: [rowValues]
+      }
+    });
+  } else {
+    await sheets.spreadsheets.values.append({
+      spreadsheetId,
+      range: sheetTitle,
+      valueInputOption: 'RAW',
+      insertDataOption: 'INSERT_ROWS',
+      requestBody: {
+        values: [rowValues]
+      }
+    });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,2 @@
+export { upsertTipo, upsertNatureza, upsertCredito } from './dicUpsert';
+export { normalizaMotivo } from './motivos';

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -1,0 +1,24 @@
+import { ensureHeaders, HEADERS_BY_SHEET } from './perdcompHeaders';
+import { createSheet, getSheetsClient, getSpreadsheetId, sheetExists } from './sheets';
+
+async function migrate(): Promise<void> {
+  getSpreadsheetId();
+
+  const sheets = await getSheetsClient();
+
+  for (const [title, headers] of Object.entries(HEADERS_BY_SHEET)) {
+    const exists = await sheetExists(title);
+    if (!exists) {
+      await createSheet(title);
+    }
+
+    await ensureHeaders(sheets, title as keyof typeof HEADERS_BY_SHEET, headers);
+  }
+
+  console.log('Migração concluída.');
+}
+
+migrate().catch((error) => {
+  console.error('Erro na migração:', error);
+  process.exit(1);
+});

--- a/src/motivos.ts
+++ b/src/motivos.ts
@@ -1,0 +1,57 @@
+const MOTIVO_RECEPCIONADO = 'Recepcionado';
+const MOTIVO_DEFERIDO = 'Deferido';
+const MOTIVO_INDEFERIDO = 'Indeferido';
+const MOTIVO_CANCELADO = 'Cancelado';
+const MOTIVO_CANCELAMENTO_NEGADO = 'Cancelamento negado';
+const MOTIVO_HOMOLOGADO = 'Homologado';
+const MOTIVO_OUTRO = 'Outro';
+
+const SITUACAO_EM_ANALISE = 'Em análise';
+const DETALHE_RECEPCIONADO = 'Recepcionado em procedimento de análise';
+const DETALHE_DIREITO_RECONHECIDO =
+  'Análise concluída com direito creditório reconhecido';
+
+export function normalizaMotivo(
+  situacao?: string,
+  detalhe?: string
+):
+  | typeof MOTIVO_RECEPCIONADO
+  | typeof MOTIVO_DEFERIDO
+  | typeof MOTIVO_INDEFERIDO
+  | typeof MOTIVO_CANCELADO
+  | typeof MOTIVO_CANCELAMENTO_NEGADO
+  | typeof MOTIVO_HOMOLOGADO
+  | typeof MOTIVO_OUTRO {
+  const situacaoTrimmed = situacao?.trim();
+  const detalheTrimmed = detalhe?.trim();
+  const detalheLower = detalheTrimmed?.toLowerCase();
+
+  if (
+    situacaoTrimmed === SITUACAO_EM_ANALISE &&
+    detalheTrimmed === DETALHE_RECEPCIONADO
+  ) {
+    return MOTIVO_RECEPCIONADO;
+  }
+
+  if (detalheTrimmed === DETALHE_DIREITO_RECONHECIDO) {
+    return MOTIVO_DEFERIDO;
+  }
+
+  if (detalheLower?.includes('análise concluída') && detalheLower.includes('indeferi')) {
+    return MOTIVO_INDEFERIDO;
+  }
+
+  if (detalheTrimmed === 'Pedido de cancelamento deferido') {
+    return MOTIVO_CANCELADO;
+  }
+
+  if (detalheTrimmed === 'Pedido de cancelamento indeferido') {
+    return MOTIVO_CANCELAMENTO_NEGADO;
+  }
+
+  if (detalheTrimmed === 'Homologado') {
+    return MOTIVO_HOMOLOGADO;
+  }
+
+  return MOTIVO_OUTRO;
+}

--- a/src/perdcompHeaders.ts
+++ b/src/perdcompHeaders.ts
@@ -1,0 +1,142 @@
+import { sheets_v4 } from 'googleapis';
+import { getHeaderRange, getSheetId, getSpreadsheetId } from './sheets';
+
+/*
+ * Observações de negócio (futuro):
+ * - No card (UI), o total exibido deve considerar todos os eventos exceto cancelamentos.
+ * - As linhas do card devem ser agregadas por família (DCOMP, REST, RESSARC) e somar
+ *   naturezas com o mesmo nome, sem exibir os códigos numéricos.
+ * - Caso naturezas distintas tenham nomes diferentes dentro da mesma família, devem
+ *   aparecer em linhas separadas.
+ * - Cancelamentos ficam restritos ao modal e não entram no total nem nas quebras.
+ * - Ao persistir eventos PERDCOMP futuramente, usar normalizaMotivo para preencher
+ *   a coluna Motivo_Normalizado e realizar upserts de naturezas/créditos antes do
+ *   salvamento para registrar inéditos.
+ */
+
+export const PERDCOMP_HEADERS = [
+  'Perdcomp_Bruto',
+  'Perdcomp_Formatado',
+  'Data_Transmissao',
+  'Data_ISO',
+  'Tipo_Bloco4',
+  'Tipo_Documento_RFB',
+  'Natureza',
+  'Familia',
+  'Credito',
+  'Credito_Descricao',
+  'CNPJ',
+  'Solicitante',
+  'Situacao',
+  'Situacao_Detalhamento',
+  'Motivo_Normalizado',
+  'Site_Receipt_URL',
+  'Ultima_Atualizacao'
+] as const;
+
+export const DIC_TIPOS_HEADERS = [
+  'Chave',
+  'Bloco',
+  'Codigo',
+  'Nome',
+  'Descricao',
+  'Fonte',
+  'Exemplo_PERDCOMP',
+  'Ult_Atualizacao'
+] as const;
+
+export const DIC_NATUREZAS_HEADERS = [
+  'Chave',
+  'Bloco',
+  'Codigo',
+  'Familia',
+  'Nome',
+  'Observacao',
+  'Fonte',
+  'Exemplo_PERDCOMP',
+  'Ult_Atualizacao'
+] as const;
+
+export const DIC_CREDITOS_HEADERS = [
+  'Chave',
+  'Bloco',
+  'Codigo',
+  'Descricao',
+  'Fonte',
+  'Exemplo_PERDCOMP',
+  'Ult_Atualizacao'
+] as const;
+
+type HeaderArray = readonly string[];
+
+type HeaderRecord = Record<string, HeaderArray>;
+
+export const HEADERS_BY_SHEET: HeaderRecord = {
+  PERDCOMP: PERDCOMP_HEADERS,
+  DIC_TIPOS: DIC_TIPOS_HEADERS,
+  DIC_NATUREZAS: DIC_NATUREZAS_HEADERS,
+  DIC_CREDITOS: DIC_CREDITOS_HEADERS
+};
+
+export async function ensureHeaders(
+  sheets: sheets_v4.Sheets,
+  title: keyof typeof HEADERS_BY_SHEET,
+  headers: HeaderArray
+): Promise<void> {
+  const spreadsheetId = getSpreadsheetId();
+  const headerRange = `${title}!${getHeaderRange(headers)}`;
+
+  await sheets.spreadsheets.values.update({
+    spreadsheetId,
+    range: headerRange,
+    valueInputOption: 'RAW',
+    requestBody: {
+      values: [Array.from(headers)]
+    }
+  });
+
+  const sheetId = await getSheetId(title);
+  if (sheetId === undefined) {
+    throw new Error(`Sheet ID not found for title ${title}`);
+  }
+
+  const requests: sheets_v4.Schema$Request[] = [
+    {
+      repeatCell: {
+        range: {
+          sheetId,
+          startRowIndex: 0,
+          endRowIndex: 1,
+          startColumnIndex: 0,
+          endColumnIndex: headers.length
+        },
+        cell: {
+          userEnteredFormat: {
+            textFormat: {
+              bold: true
+            }
+          }
+        },
+        fields: 'userEnteredFormat.textFormat.bold'
+      }
+    },
+    {
+      updateSheetProperties: {
+        properties: {
+          sheetId,
+          gridProperties: {
+            frozenRowCount: 1
+          }
+        },
+        fields: 'gridProperties.frozenRowCount'
+      }
+    }
+  ];
+
+  await sheets.spreadsheets.batchUpdate({
+    spreadsheetId,
+    requestBody: {
+      requests
+    }
+  });
+}

--- a/src/sheets.ts
+++ b/src/sheets.ts
@@ -1,0 +1,115 @@
+import { google, sheets_v4 } from 'googleapis';
+
+const SCOPES = ['https://www.googleapis.com/auth/spreadsheets'];
+
+let sheetsClientPromise: Promise<sheets_v4.Sheets> | undefined;
+
+export function getSpreadsheetId(): string {
+  const spreadsheetId = process.env.SHEET_ID;
+  if (!spreadsheetId) {
+    throw new Error('SHEET_ID environment variable is not defined.');
+  }
+  return spreadsheetId;
+}
+
+export async function getSheetsClient(): Promise<sheets_v4.Sheets> {
+  if (!sheetsClientPromise) {
+    const auth = new google.auth.GoogleAuth({
+      scopes: SCOPES
+    });
+    const authClient = await auth.getClient();
+    sheetsClientPromise = Promise.resolve(google.sheets({
+      version: 'v4',
+      auth: authClient
+    }));
+  }
+  return sheetsClientPromise;
+}
+
+export async function getSpreadsheet(): Promise<sheets_v4.Schema$Spreadsheet> {
+  const sheets = await getSheetsClient();
+  const spreadsheetId = getSpreadsheetId();
+  const response = await sheets.spreadsheets.get({
+    spreadsheetId
+  });
+  return response.data;
+}
+
+export async function sheetExists(title: string): Promise<boolean> {
+  const spreadsheet = await getSpreadsheet();
+  return (spreadsheet.sheets ?? []).some(
+    (sheet) => sheet.properties?.title === title
+  );
+}
+
+export async function getSheetId(title: string): Promise<number | undefined> {
+  const spreadsheet = await getSpreadsheet();
+  const foundSheet = (spreadsheet.sheets ?? []).find(
+    (sheet) => sheet.properties?.title === title
+  );
+  return foundSheet?.properties?.sheetId ?? undefined;
+}
+
+export async function createSheet(title: string): Promise<void> {
+  const sheets = await getSheetsClient();
+  const spreadsheetId = getSpreadsheetId();
+  await sheets.spreadsheets.batchUpdate({
+    spreadsheetId,
+    requestBody: {
+      requests: [
+        {
+          addSheet: {
+            properties: {
+              title
+            }
+          }
+        }
+      ]
+    }
+  });
+}
+
+export function getHeaderRange(headers: readonly string[]): string {
+  const lastColumn = headers.length;
+  const lastColumnLetter = toColumnLetter(lastColumn);
+  return `A1:${lastColumnLetter}1`;
+}
+
+export function getRowRange(headers: readonly string[], rowIndex: number): string {
+  const lastColumnLetter = toColumnLetter(headers.length);
+  return `A${rowIndex}:${lastColumnLetter}${rowIndex}`;
+}
+
+export async function getKeyRowMap(title: string): Promise<Map<string, number>> {
+  const sheets = await getSheetsClient();
+  const spreadsheetId = getSpreadsheetId();
+  const response = await sheets.spreadsheets.values.get({
+    spreadsheetId,
+    range: `${title}!A:A`
+  });
+
+  const rows = response.data.values ?? [];
+  const map = new Map<string, number>();
+  rows.forEach((row, index) => {
+    const rowIndex = index + 1;
+    if (rowIndex === 1) {
+      return;
+    }
+    const key = row[0];
+    if (key) {
+      map.set(String(key), rowIndex);
+    }
+  });
+  return map;
+}
+
+function toColumnLetter(columnNumber: number): string {
+  let temp = columnNumber;
+  let letter = '';
+  while (temp > 0) {
+    const modulo = (temp - 1) % 26;
+    letter = String.fromCharCode(65 + modulo) + letter;
+    temp = Math.floor((temp - modulo) / 26);
+  }
+  return letter;
+}

--- a/tsconfig.sheets.json
+++ b/tsconfig.sheets.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "noEmit": true,
+    "types": ["node"],
+    "resolveJsonModule": true,
+    "esModuleInterop": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- add Google Sheets helpers to create or format PERDCOMP and dictionary tabs with required headers
- provide idempotent migration script and dictionary upsert utilities for types, naturezas, and créditos
- expose motivo normalization helper and public exports for dictionary upserts

## Testing
- npm run test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d4612086d4832ca37b0c2db0770c21