### PR TITLE
Atualiza agregação e exibição de PER/DCOMP

### DIFF
--- a/utils/perdcomp.ts
+++ b/utils/perdcomp.ts
@@ -1,121 +1,127 @@
-export type PerdcompTipo = 'DCOMP' | 'REST' | 'CANC' | 'DESCONHECIDO';
-export type FamiliaTipo = 'DCOMP' | 'REST' | 'RESSARC' | 'CANC' | 'DESCONHECIDO';
+export type PerdcompTipo = 'DCOMP' | 'REST' | 'RESSARC' | 'CANC' | 'DESCONHECIDO';
 
-export function formatPerdcompNumero(raw: string): string {
-  const digits = (raw || '').replace(/\D/g, '');
-  // PER/DCOMP "compacto": 24 dígitos = 5+5+6+1+1+2+4
-  if (digits.length === 24) {
-    const b1 = digits.slice(0, 5);   // seq
-    const b2 = digits.slice(5, 10);  // controle
-    const b3 = digits.slice(10, 16); // data DDMMAA
-    const b4 = digits.slice(16, 17); // tipo (1/2/8)
-    const b5 = digits.slice(17, 18); // natureza: 1.x → x aqui
-    const b6 = digits.slice(18, 20); // crédito
-    const suf = digits.slice(20, 24); // protocolo (4)
-    return `${b1}.${b2}.${b3}.${b4}.${b5}.${b6}-${suf}`;
-  }
-  // Se já vier formatado, devolve como está
-  return raw ?? '';
-}
-
-export function parsePerdcompNumero(raw: string) {
-  const formatted = formatPerdcompNumero(raw);
-  const rx = /^(\d{5})\.(\d{5})\.(\d{6})\.(\d)\.(\d)\.(\d{2})-(\d{4})$/;
-  const m = formatted.match(rx);
-  if (!m) return { valido: false as const };
-
-  const [, , , ddmmaa, tipoStr, natDigit, credito, protocolo] = m;
-
-  const tipoNum = Number(tipoStr);
-  const tipo: PerdcompTipo =
-    tipoNum === 1 ? 'DCOMP' :
-    tipoNum === 2 ? 'REST'  :
-    tipoNum === 8 ? 'CANC'  :
-    'DESCONHECIDO';
-
-  // natureza "1.x" (bloco 5)
-  const natureza = `1.${natDigit}`;
-
-  // data ISO (assumindo século 2000–2099)
-  const dd = ddmmaa.slice(0, 2);
-  const mm = ddmmaa.slice(2, 4);
-  const aa = ddmmaa.slice(4, 6);
-  const ano = 2000 + Number(aa);
-  const dataISO = `${ano}-${mm}-${dd}`;
-
-  return {
-    valido: true as const,
-    formatted,
-    tipo, natureza, credito, protocolo, dataISO,
-  };
-}
-
-// Natureza (bloco 5) mapeada para a família principal
-export const NATUREZA_TO_FAMILIA: Record<string, FamiliaTipo> = {
-  '1.1': 'RESSARC',
-  '1.5': 'RESSARC',
-
-  '1.2': 'REST',
-  '1.6': 'REST',
-
-  '1.3': 'DCOMP',
-  '1.7': 'DCOMP',
-
-  '1.8': 'CANC',
+export const DEFAULT_FAMILIA_LABELS: Record<PerdcompTipo, string> = {
+  DCOMP: 'DCOMP (Declarações de Compensação)',
+  REST: 'REST (Pedidos de Restituição)',
+  RESSARC: 'RESSARC (Pedidos de Ressarcimento)',
+  CANC: 'Cancelamentos',
+  DESCONHECIDO: 'Desconhecido',
 };
 
-export function classificaFamiliaPorNatureza(natureza: string): FamiliaTipo {
-  return NATUREZA_TO_FAMILIA[natureza] ?? 'DESCONHECIDO';
+export type NaturezaInfo = { familia: PerdcompTipo; nome: string };
+
+// TODO: trocar por leitura do dicionário da planilha.
+// Fallback mínimo para já funcionar agora.
+export const NATUREZA_FALLBACK: Record<string, NaturezaInfo> = {
+  '1.3': { familia: 'DCOMP', nome: DEFAULT_FAMILIA_LABELS.DCOMP },
+  '1.7': { familia: 'DCOMP', nome: DEFAULT_FAMILIA_LABELS.DCOMP },
+  '1.2': { familia: 'REST', nome: DEFAULT_FAMILIA_LABELS.REST },
+  '1.6': { familia: 'REST', nome: DEFAULT_FAMILIA_LABELS.REST },
+  '1.1': { familia: 'RESSARC', nome: DEFAULT_FAMILIA_LABELS.RESSARC },
+  '1.5': { familia: 'RESSARC', nome: DEFAULT_FAMILIA_LABELS.RESSARC },
+  '1.8': { familia: 'CANC', nome: DEFAULT_FAMILIA_LABELS.CANC },
+  // Outros cairão como desconhecidos até o dicionário ser preenchido
+};
+
+export function formatPerdcompNumero(raw: string) {
+  const digits = String(raw ?? '').replace(/\D/g, '');
+  if (digits.length < 24) return raw;
+  const useDigits = digits.slice(-24);
+  const b1 = useDigits.slice(0, 5);
+  const b2 = useDigits.slice(5, 10);
+  const b3 = useDigits.slice(10, 16);
+  const b4 = useDigits.slice(16, 17);
+  const b5 = useDigits.slice(17, 18);
+  const b6 = useDigits.slice(18, 20);
+  const suf = useDigits.slice(20, 24);
+  return `${b1}.${b2}.${b3}.${b4}.${b5}.${b6}-${suf}`;
 }
 
-export function agregaPerdcomp(lista: Array<{ perdcomp?: string }>) {
+export function parsePerdcompNumero(numero: string) {
+  const formatted = formatPerdcompNumero(numero);
+  const m = formatted.match(/^(\d{5})\.(\d{5})\.(\d{6})\.(\d)\.(\d)\.(\d{2})-(\d{4})$/);
+  if (!m) return null;
+  const [, , , , tipoStr, nat1, cred] = m;
+  const tipoNum = Number(tipoStr);
+  const tipo: PerdcompTipo =
+    tipoNum === 1 ? 'DCOMP' : tipoNum === 2 ? 'REST' : tipoNum === 8 ? 'CANC' : 'DESCONHECIDO';
+  const natureza = `1.${nat1}`;
+  return { formatted, tipo, natureza, credito: cred };
+}
+
+export type ResumoPerdcomp = {
+  total: number; // bruto
+  totalSemCancelamento: number; // para o card
+  canc: number;
+  breakdown: Array<{ nome: string; familia: PerdcompTipo; quantidade: number }>;
+};
+
+export function agregaPerdcomp(lista: Array<{ perdcomp?: string }>): ResumoPerdcomp {
+  const porNome = new Map<string, { nome: string; familia: PerdcompTipo; quantidade: number }>();
   let total = 0;
   let canc = 0;
 
-  const porFamilia: Record<FamiliaTipo, number> = {
-    DCOMP: 0,
-    REST: 0,
-    RESSARC: 0,
-    CANC: 0,
-    DESCONHECIDO: 0,
-  };
+  for (const item of lista ?? []) {
+    const numero = item?.perdcomp;
+    if (!numero) continue;
+    const parsed = parsePerdcompNumero(numero);
+    if (!parsed) continue;
 
-  // Naturezas agrupadas para exibição no card
-  const porNaturezaAgrupada: Record<string, number> = {
-    '1.3/1.7': 0,
-    '1.2/1.6': 0,
-    '1.1/1.5': 0,
-  };
+    total += 1;
 
-  for (const it of lista ?? []) {
-    const num = it?.perdcomp;
-    if (!num) continue;
-    const p = parsePerdcompNumero(num);
-    if (!p.valido) continue;
+    const info = NATUREZA_FALLBACK[parsed.natureza] ?? {
+      familia: parsed.tipo,
+      nome: DEFAULT_FAMILIA_LABELS[parsed.tipo] ?? parsed.tipo,
+    };
 
-    total++;
-
-    const familia = classificaFamiliaPorNatureza(p.natureza);
-    porFamilia[familia] = (porFamilia[familia] ?? 0) + 1;
-
-    if (p.natureza === '1.3' || p.natureza === '1.7') {
-      porNaturezaAgrupada['1.3/1.7']++;
-    }
-    if (p.natureza === '1.2' || p.natureza === '1.6') {
-      porNaturezaAgrupada['1.2/1.6']++;
-    }
-    if (p.natureza === '1.1' || p.natureza === '1.5') {
-      porNaturezaAgrupada['1.1/1.5']++;
+    if (info.familia === 'CANC') {
+      canc += 1;
+      continue;
     }
 
-    if (familia === 'CANC') canc++;
+    const key = info.nome;
+    const atual = porNome.get(key);
+    if (atual) {
+      atual.quantidade += 1;
+    } else {
+      porNome.set(key, { nome: info.nome, familia: info.familia, quantidade: 1 });
+    }
   }
+
+  const ordemFamilia: Record<PerdcompTipo, number> = {
+    DCOMP: 1,
+    REST: 2,
+    RESSARC: 3,
+    DESCONHECIDO: 9,
+    CANC: 99,
+  };
+
+  const breakdown = [...porNome.values()].sort(
+    (a, b) => (ordemFamilia[a.familia] ?? 9) - (ordemFamilia[b.familia] ?? 9)
+  );
+
+  const totalSemCancelamento = total - canc;
 
   return {
     total,
-    totalSemCancelamento: total - canc,
+    totalSemCancelamento,
     canc,
-    porFamilia,
-    porNaturezaAgrupada,
+    breakdown,
   };
+}
+
+export function contaPorFamilia(resumo: ResumoPerdcomp): Record<PerdcompTipo, number> {
+  const base: Record<PerdcompTipo, number> = {
+    DCOMP: 0,
+    REST: 0,
+    RESSARC: 0,
+    CANC: resumo.canc,
+    DESCONHECIDO: 0,
+  };
+
+  for (const row of resumo.breakdown) {
+    base[row.familia] = (base[row.familia] ?? 0) + row.quantidade;
+  }
+
+  return base;
 }


### PR DESCRIPTION
## Resumo
- revisa utilitário de PER/DCOMP para agrupar naturezas por nome e excluir cancelamentos do total exibido
- ajusta a rota de PER/DCOMP para devolver o novo resumo agregado e atualizar a planilha com os totais por família
- atualiza o card de resultados para usar os novos dados agregados, exibir a soma por família sem códigos e mover cancelamentos para o modal

## Testes
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d46b493980832c83a19eaef553b8f3